### PR TITLE
[CI] fix tox -e lint by adding formatting config files pyproject.toml and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.{py,pyi,toml,md}]
+charset = "utf-8"
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 88

--- a/fixit/common/base.py
+++ b/fixit/common/base.py
@@ -19,6 +19,7 @@ from libcst.metadata import (
 
 from fixit.common.report import BaseLintRuleReport, CstLintRuleReport
 
+
 if TYPE_CHECKING:
     # lint-ignore: F401: Used by quoted type
     from fixit.common.pseudo_rule import PseudoLintRule  # noqa: F401

--- a/fixit/common/cli/__init__.py
+++ b/fixit/common/cli/__init__.py
@@ -17,6 +17,7 @@ from typing import Callable, Collection, Iterable, Iterator, Tuple, TypeVar, Uni
 
 from fixit.common.config import REPO_ROOT
 
+
 _MapPathsOperationConfigT = TypeVar("_MapPathsOperationConfigT")
 _MapPathsOperationResultT = TypeVar("_MapPathsOperationResultT")
 _MapPathsOperationT = Callable[

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 from typing import Any, Mapping, Pattern, Union
 
+
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent.parent.parent.parent
 DISTILLERY_ROOT: Path = REPO_ROOT / "distillery"
 

--- a/fixit/common/flake8_compat.py
+++ b/fixit/common/flake8_compat.py
@@ -12,8 +12,10 @@ import tokenize
 from functools import lru_cache
 from typing import Any, Iterable, List, Optional, Type
 
-from flake8.checker import FileChecker as Flake8FileChecker
-from flake8.checker import Manager as Flake8CheckerManager
+from flake8.checker import (
+    FileChecker as Flake8FileChecker,
+    Manager as Flake8CheckerManager,
+)
 from flake8.formatting.base import BaseFormatter as Flake8BaseFormatter
 from flake8.main.application import Application as Flake8BaseApplication
 from flake8.processor import FileProcessor as Flake8FileProcessor
@@ -22,6 +24,7 @@ from flake8.style_guide import Violation as Flake8Violation
 from fixit.common.config import REPO_ROOT
 from fixit.common.pseudo_rule import PseudoContext, PseudoLintRule
 from fixit.common.report import BaseLintRuleReport
+
 
 __all__ = ["Flake8LintRuleReport", "Flake8PseudoLintRule"]
 

--- a/fixit/common/ignores.py
+++ b/fixit/common/ignores.py
@@ -25,6 +25,7 @@ from fixit.common.line_mapping import LineMappingInfo
 from fixit.common.pseudo_rule import PseudoLintRule
 from fixit.common.report import BaseLintRuleReport
 
+
 _LintRuleT = Union[Type[CstLintRule], Type[PseudoLintRule]]
 
 

--- a/fixit/common/insert_suppressions.py
+++ b/fixit/common/insert_suppressions.py
@@ -8,13 +8,12 @@ import textwrap
 import tokenize
 from collections import deque
 from dataclasses import dataclass
-
-# lint-ignore: IG29: The linter shouldn't depend on distillery's libs
 from enum import Enum
 from io import BytesIO
 from typing import Iterable, Mapping, Optional, Sequence
 
 from fixit.common.line_mapping import LineMappingInfo
+
 
 BODY_PREFIX = "# lint:"
 BODY_PREFIX_WITH_SPACE = f"{BODY_PREFIX} "

--- a/fixit/common/line_mapping.py
+++ b/fixit/common/line_mapping.py
@@ -8,6 +8,7 @@ from bisect import bisect_left
 from dataclasses import dataclass
 from typing import Container, Iterable, Mapping, Optional, Sequence
 
+
 _LOGICAL_LINE_END_MARKERS: Container[int] = (
     tokenize.NL,
     tokenize.NEWLINE,

--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -5,7 +5,7 @@
 
 import re
 import textwrap
-from typing import Iterable, Optional, Tuple, Type, Union, Any
+from typing import Iterable, Optional, Tuple, Type, Union
 
 from libcst.testing.utils import (  # noqa IG69: this module is only used by tests
     UnitTest,
@@ -22,13 +22,15 @@ def _dedent(src: str) -> str:
     src = re.sub(r"\A\n", "", src)
     return textwrap.dedent(src)
 
-def data_provider_DEPRECATED(fn_data_provider):
+
+def data_provider_DEPRECATED(fn_data_provider):  # noqa: C901
     """
     NOTE: This data provider method is deprecated in favor of a newer version.  Please
     use that one instead.
 
     Data provider decorator, allows another callable to provide the data for the testself.
     """
+    # TODO: data_provider_DEPRECATED should be replaced by data_provider
     def test_decorator(fn):
         def repl(self, *args) -> None:
             provided_data = fn_data_provider(self)
@@ -87,7 +89,6 @@ def data_provider_DEPRECATED(fn_data_provider):
         return repl
 
     return test_decorator
-
 
 
 # We can't use an ABCMeta here, because of metaclass conflicts

--- a/fixit/common/tests/test_pseudo_rule.py
+++ b/fixit/common/tests/test_pseudo_rule.py
@@ -15,6 +15,7 @@ from fixit.common.pseudo_rule import PseudoContext, PseudoLintRule
 from fixit.common.report import BaseLintRuleReport
 from fixit.rule_lint_engine import lint_file
 
+
 DUMMY_FILE_PATH = Path(__file__)
 DUMMY_SOURCE = b"pass\npass\npass\n"
 DUMMY_LINT_CODE = "IG00"

--- a/fixit/common/tests/test_rules.py
+++ b/fixit/common/tests/test_rules.py
@@ -3,9 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from libcst.testing.utils import (
+from libcst.testing.utils import (  # noqa IG69: this module is only used by tests
     UnitTest,
-)  # noqa IG69: this module is only used by tests
+)
 
 from fixit import rule_lint_engine
 

--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -38,6 +38,7 @@ from fixit.common.line_mapping import LineMappingInfo
 from fixit.common.pseudo_rule import PseudoContext, PseudoLintRule
 from fixit.common.report import BaseLintRuleReport
 
+
 LintRuleCollectionT = List[Union[Type[CstLintRule], Type[PseudoLintRule]]]
 
 

--- a/fixit/rules/avoid_or_in_except.py
+++ b/fixit/rules/avoid_or_in_except.py
@@ -7,8 +7,7 @@ import libcst as cst
 import libcst.matchers as m
 
 from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class AvoidOrInExceptRule(CstLintRule):

--- a/fixit/rules/cls_in_classmethod.py
+++ b/fixit/rules/cls_in_classmethod.py
@@ -15,8 +15,8 @@ from libcst.metadata import (
 )
 
 from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+
 
 CLS = "cls"
 

--- a/fixit/rules/compare_primitives_by_equal.py
+++ b/fixit/rules/compare_primitives_by_equal.py
@@ -6,8 +6,7 @@
 import libcst as cst
 
 from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class ComparePrimitivesByEqualRule(CstLintRule):

--- a/fixit/rules/gather_sequential_await.py
+++ b/fixit/rules/gather_sequential_await.py
@@ -6,8 +6,7 @@
 import libcst as cst
 
 from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class GatherSequentialAwaitRule(CstLintRule):

--- a/fixit/rules/no_assert_equals.py
+++ b/fixit/rules/no_assert_equals.py
@@ -7,8 +7,7 @@ import libcst as cst
 import libcst.matchers as m
 
 from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class NoAssertEqualsRule(CstLintRule):

--- a/fixit/rules/no_implicit_concat.py
+++ b/fixit/rules/no_implicit_concat.py
@@ -8,8 +8,7 @@ from typing import List
 import libcst as cst
 
 from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class UsePlusForStringConcatRule(CstLintRule):

--- a/fixit/rules/no_static_if_condition.py
+++ b/fixit/rules/no_static_if_condition.py
@@ -9,8 +9,7 @@ import libcst as cst
 import libcst.matchers as m
 
 from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class NoStaticIfConditionRule(CstLintRule):

--- a/fixit/rules/replace_union_with_optional.py
+++ b/fixit/rules/replace_union_with_optional.py
@@ -7,8 +7,7 @@ import libcst as cst
 import libcst.matchers as m
 
 from fixit.common.base import CstContext, CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class ReplaceUnionWithOptionalRule(CstLintRule):

--- a/fixit/rules/unnecessary_list_comprehension.py
+++ b/fixit/rules/unnecessary_list_comprehension.py
@@ -7,8 +7,8 @@ import libcst as cst
 import libcst.matchers as m
 
 from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+
 
 IG66_UNNECESSARY_LIST_COMPREHENSION: str = (
     "IG66 Unnecessary list comprehension - {func} can take a generator, and is likely "

--- a/fixit/rules/use_types_from_typing.py
+++ b/fixit/rules/use_types_from_typing.py
@@ -9,8 +9,8 @@ import libcst
 from libcst.metadata import ScopeProvider
 
 from fixit.common.base import CstContext, CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid
-from fixit.common.utils import ValidTestCase as Valid
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+
 
 IG117_REPLACE_BUILTIN_TYPE_ANNOTATION: str = (
     "IG117 You are using builtins.{builtin_type} as a type annotation "

--- a/fixit/tests/test_rules.py
+++ b/fixit/tests/test_rules.py
@@ -14,6 +14,7 @@ from fixit.common.base import CstLintRule
 from fixit.common.testing import LintRuleTest
 from fixit.rule_lint_engine import RULES
 
+
 if TYPE_CHECKING:
     from fixit.common.utils import ValidTestCase, InvalidTestCase
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+target-version = ["py36"]
+
+[tool.isort]
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+lines_after_imports = 2
+combine_as_imports = true
+not_skip = "__init__.py"

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from os import path
 # pyre-ignore Pyre doesn't know about setuptools.
 import setuptools
 
+
 # Grab the readme so that our package stays in sync with github.
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:


### PR DESCRIPTION
# Summary
`pyproject.toml` provides formatting config to Black.
`.editorconfig` provides formatting config to isort.
Use the same config as LibCST for consistency.

# Test Plan
```
$ tox -e lint
GLOB sdist-make: /Users/jimmylai/github/Fixit/setup.py
lint inst-nodeps: /Users/jimmylai/github/Fixit/.tox/.tmp/package/1/fixit-0.0.1.zip
lint installed: alabaster==0.7.12,appdirs==1.4.3,appnope==0.1.0,attrs==19.3.0,Babel==2.8.0,backcall==0.1.0,black==19.10b0,bleach==3.1.1,certifi==2019.11.2
8,chardet==3.0.4,Click==7.0,codecov==2.0.15,coverage==4.5.4,decorator==4.4.2,defusedxml==0.6.0,docutils==0.16,entrypoints==0.3,fixit==0.0.1,flake8==3.7.9,
idna==2.9,imagesize==1.2.0,importlib-metadata==1.5.0,ipykernel==5.1.4,ipython==7.13.0,ipython-genutils==0.2.0,ipywidgets==7.5.1,isort==4.3.20,jedi==0.16.0
,Jinja2==2.11.1,jsonschema==3.2.0,jupyter==1.0.0,jupyter-client==6.0.0,jupyter-console==6.1.0,jupyter-core==4.6.3,libcst==0.3.2,MarkupSafe==1.1.1,mccabe==
0.6.1,mistune==0.8.4,mypy-extensions==0.4.3,nbconvert==5.6.1,nbformat==5.0.4,nbsphinx==0.4.2,notebook==6.0.3,packaging==20.1,pandocfilters==1.4.2,parso==0
.6.2,pathspec==0.7.0,pexpect==4.8.0,pickleshare==0.7.5,prometheus-client==0.7.1,prompt-toolkit==2.0.9,psutil==5.7.0,ptyprocess==0.6.0,pycodestyle==2.5.0,p
yflakes==2.1.1,Pygments==2.5.2,pyparsing==2.4.6,pyre-check==0.0.41,pyre-extensions==0.0.17,pyrsistent==0.15.7,python-dateutil==2.8.1,pytz==2019.3,pywatchm
an==1.4.1,PyYAML==5.2,pyzmq==19.0.0,qtconsole==4.7.1,QtPy==1.9.0,regex==2020.2.20,requests==2.23.0,Send2Trash==1.5.0,six==1.14.0,snowballstemmer==2.0.0,Sp
hinx==3.0.0.dev20200304,sphinx-rtd-theme==0.4.3,sphinxcontrib-applehelp==1.0.2,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==1.0.3,sphinxcontrib-js
math==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.4,terminado==0.8.3,testpath==0.4.4,toml==0.10.0,tornado==6.0.4,traitlets==4.3.3
,typed-ast==1.4.1,typing-extensions==3.7.4.1,typing-inspect==0.5.0,urllib3==1.25.8,wcwidth==0.1.8,webencodings==0.5.1,widgetsnbextension==3.5.1,zipp==3.1.
0
lint run-test-pre: PYTHONHASHSEED='1083789714'
lint run-test: commands[0] | flake8
lint run-test: commands[1] | isort --check-only
Skipped 2 files
lint run-test: commands[2] | black --check fixit/
All done! ✨ 🍰 ✨
43 files would be left unchanged.
________________________________________________________________________ summary _________________________________________________________________________
  lint: commands succeeded
  congratulations :)
```