### PR TITLE
Fix test on libcst 0.3.3

### DIFF
--- a/fixit/rules/cls_in_classmethod.py
+++ b/fixit/rules/cls_in_classmethod.py
@@ -193,7 +193,7 @@ class ClsInClassmethodRule(CstLintRule):
 
                 @classmethod
                 def cm(cls):
-                    cls[1] = foo.cm(cls=cls)
+                    cls[1] = foo.cm(a=cls)
             """,
         ),
         Invalid(


### PR DESCRIPTION
Previously, it would rename kwargs too, which in general is not correct.  In this particular case, the replacement is now wrong, but in the way that's more likely to be correct.

I can also remove the kwarg from this call, making it actually correct, but thought it would be good to at least document (since this is the only test that started failing with 0.3.3)