### PR TITLE
Tox pyre

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,3 @@ passenv =
 commands =
     coverage run setup.py test
     codecov
-
-[testenv:pyre]
-commands =
-    pyre --search-path {env:VIRTUAL_ENV}/lib/python3.7/site-packages --search-path {env:VIRTUAL_ENV}/lib/pyre_check/typeshed/stdlib/3 --search-path {env:VIRTUAL_ENV}/lib/pyre_check/typeshed/stdlib/2and3 check


### PR DESCRIPTION
# Add Pyre to Tox and GitHub CI Workflows
- Some hackyness to get `tox -e pyre` to work in the local dev environment. BUT this requires that the command is run from within an active virtualenv that has the Pyre package installed.... :/ 
- I tried to stick with `tox` in the workflows to keep it consistent, but the hacky solution mentioned above did not work in the GH environment so reverted back to just creating a venv and running `pyre check` on each run