### PR TITLE
Bump Fixit version

### DIFF
--- a/fixit/_version.py
+++ b/fixit/_version.py
@@ -4,4 +4,4 @@
 # LICENSE file in the root directory of this source tree.
 
 
-FIXIT_VERSION: str = "0.0.dev2"
+FIXIT_VERSION: str = "0.0.dev3"


### PR DESCRIPTION
New changes include:
- more lint rules ported over from `distillery` (`CompareSingletonPrimitivesByIsRule`, `RewriteToComprehensionRule`, `RewriteToLiteralRule`)
- modularized unit testing, without the use of `data_provider`
- some cleanup in `common.testing`
See (#15)