### PR TITLE
[typing] enable Pyre strict check by default.

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -4,5 +4,6 @@
     ],
     "exclude": [
         ".*/\\.tox/.*"
-    ]
+    ],
+    "strict": true
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # -*- coding: utf-8 -*-
-#
+# pyre-unsafe
 # Configuration file for the Sphinx documentation builder.
 #
 # This file does only contain a selection of the most common options. For a

--- a/docs/source/lib.py
+++ b/docs/source/lib.py
@@ -6,7 +6,9 @@
 import difflib
 from pathlib import Path
 from textwrap import dedent, indent
+from typing import IO
 
+from fixit.common.base import LintRuleT
 from fixit.rule_lint_engine import get_rules
 
 
@@ -14,10 +16,11 @@ def _add_code_indent(code: str) -> str:
     return indent(code, "    ") + "\n"
 
 
-def write_example_cases(fp, rule, key):
+def write_example_cases(fp: IO[str], rule: LintRuleT, key: str) -> None:
     s = ""
-    if rule.__doc__:
-        s += dedent(rule.__doc__)
+    doc = rule.__doc__
+    if doc:
+        s += dedent(doc)
     if hasattr(rule, key):
         line = f"{key} Code Examples"
         line_len = len(line)
@@ -70,7 +73,7 @@ def _get_dashed_rule_name_from_camel_case(name: str) -> str:
     return rule_name
 
 
-def create_rule_doc():
+def create_rule_doc() -> None:
     directory = Path(__file__).parent / "rules"
     directory.mkdir(exist_ok=True)
 

--- a/setup.py
+++ b/setup.py
@@ -4,21 +4,23 @@
 # LICENSE file in the root directory of this source tree.
 
 import importlib.util
+from importlib.machinery import ModuleSpec
 from os import path
+from types import ModuleType
 
 import setuptools
 
 
 # Grab the readme so that our package stays in sync with github.
-this_directory = path.abspath(path.dirname(__file__))
+this_directory: str = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 # Grab the version constant so that libcst.tool stays in sync with this package.
-spec = importlib.util.spec_from_file_location(
+spec: ModuleSpec = importlib.util.spec_from_file_location(
     "version", path.join(this_directory, "fixit/_version.py")
 )
-version = importlib.util.module_from_spec(spec)
+version: ModuleType = importlib.util.module_from_spec(spec)
 # pyre-ignore Pyre doesn't know about importlib entirely.
 spec.loader.exec_module(version)
 # pyre-ignore Pyre has no way of knowing that this constant exists.


### PR DESCRIPTION
Enable Pyre strict check by default. So we don't need to manually add `pyre-strict`.

Test Plan: Ci pyre builds.