### PR TITLE
Upgrade libcst version to latest 0.3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flake8==3.8.1
-libcst==0.3.3
+libcst==0.3.6
 pyyaml==5.2


### PR DESCRIPTION
as title. Made extra changes to fix type error since now the scope analysis reference node can also be an `Attribute`.