### PR TITLE
[CI] add simple test coverage report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,34 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           pyre --preserve-pythonpath check
+
+  coverage:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8]
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set Up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Env
+        run: |
+          python -VV
+      - name: Tox
+        run: |
+          python -m pip install tox
+          tox --version
+      - name: coverage
+        run: |
+          tox -e coverage
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage_report.html
+          path: coverage_report.html

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ docs/source/.ipynb_checkpoints/
 build/
 .coverage
 docs/source/rules/
+coverage.xml
+coverage_report.html

--- a/fixit/rules/cls_in_classmethod.py
+++ b/fixit/rules/cls_in_classmethod.py
@@ -236,7 +236,6 @@ class ClsInClassmethodRule(CstLintRule):
             for decorator in node.decorators
         ):
             return  # If it's not a @classmethod, we are not interested.
-
         if not node.params.params:
             # No params, but there must be the 'cls' param.
             # Note that pyre[47] already catches this, but we also generate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ pyre-check==0.0.41
 sphinx-rtd-theme==0.4.3
 prompt-toolkit==2.0.9
 tox==3.14.5
+diff_cover==3.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -42,4 +42,5 @@ passenv =
     CIRCLE_*
 commands =
     coverage run setup.py test
-    codecov
+    coverage xml
+    diff-cover coverage.xml --html-report coverage_report.html


### PR DESCRIPTION
The codecov tool used in LibCST is not available until Fixit is open source.

Use a simple tool `diff-cover` to generate a html coverage report as a build artifact in new coverage workflow.

The tool run locally with `tox -e coverage` and it generates a `coverage_report.html` report file.

The report file can be found as a built artifact in PR actions and it shows line number not covered by new changes.

# Test Plan
Touched a line to trigger a buld.

![image](https://user-images.githubusercontent.com/3840867/85211018-f974be80-b2f9-11ea-9956-23489a69713e.png)


![image](https://user-images.githubusercontent.com/3840867/85210880-9afb1080-b2f8-11ea-8d95-af259b38481f.png)
