### PR TITLE
Tox commands with optional args

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,31 +6,31 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    python -m unittest
+    python -m unittest {posargs}
 
 [testenv:lint]
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    flake8
-    isort --check-only
-    black --check .
+    flake8 {posargs}
+    isort --check-only -rc {posargs:.}
+    black --check {posargs:.}
 
 [testenv:docs]
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    sphinx-build docs/source/ docs/build/
+    sphinx-build {posargs:docs/source/ docs/build/}
 
 [testenv:autofix]
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    isort -y -q
-    black .
+    isort -y -q -rc {posargs:.}
+    black {posargs:.}
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
## Summary
To provide a developer with the ability to run `tox` commands on specific directories or files during local development. 


## Testing
### `tox -e lint`:
- run on a directory:
```
tox -e lint fixit/common
```
- run on a file:
```
tox -e lint fixit/common/cli/args.py
```
- run with no args:
```
tox -e lint
```

### `tox -e autofix`:
- run on a directory:
```
tox -e autofix fixit/common
```
- run on a file:
```
tox -e autofix fixit/common/cli/args.py
```
- run with no args:
```
tox -e autofix
```

### `tox -e py<version>` for unittests:
- run all test cases in a directory:
```
tox -e py<version> fixit.tests
```
- run specific test case:
```
tox -e py<version> fixit.tests.AvoidOrInExceptRule
```
- run with no args:
```
tox -e py<version>
```