### PR TITLE
[bug] Fix AwaitAsyncCallRule annotation parse

### DIFF
--- a/fixit/rules/await_async_call.py
+++ b/fixit/rules/await_async_call.py
@@ -308,7 +308,12 @@ class AwaitAsyncCallRule(CstLintRule):
         if not annotation.startswith("typing.Callable"):
             # Exit early if this is not even a `typing.Callable` annotation.
             return False
-        parsed_ann = cst.parse_module(annotation)
+        try:
+            # Wrap this in a try-except since the type annotation may not be parse-able as a module.
+            # If it is not parse-able, we know it's not what we are looking for anyway, so return `False`.
+            parsed_ann = cst.parse_module(annotation)
+        except Exception:
+            return False
         # If passed annotation does not match the expected annotation structure for a `typing.Callable` with
         # typing.Coroutine as the return type, matched_callable_ann will simply be `None`.
         # The expected structure of an awaitable callable annotation from Pyre is: typing.Callable()[[...], typing.Coroutine[...]]


### PR DESCRIPTION
## Summary
- Wrap the parsing of a pyre-reported annotation in a try-catch since some annotations may not be parsable by libcst as modules. 
- for example, encountered a type annotation which included the following: `[AnyStr :> ...]` where special characters caused `libcst.parse_module()` to throw a [ParserSyntaxError](https://github.com/Instagram/LibCST/blob/c023fa7c4caff3fd2b3946080f9a58b539b10363/libcst/_parser/base_parser.py#L191).
- Catch any exception thrown by `parse_module()` and return False 