### PR TITLE
Bump to 0.0.dev6.1

### DIFF
--- a/fixit/_version.py
+++ b/fixit/_version.py
@@ -4,4 +4,4 @@
 # LICENSE file in the root directory of this source tree.
 
 
-FIXIT_VERSION: str = "0.0.dev6"
+FIXIT_VERSION: str = "0.0.dev6.1"


### PR DESCRIPTION
## Summary
- Bump to 0.0.dev6.1 which contains new `extra` attributes in LintOpts 