### PR TITLE
Replace version number

### DIFF
--- a/fixit/_version.py
+++ b/fixit/_version.py
@@ -4,4 +4,4 @@
 # LICENSE file in the root directory of this source tree.
 
 
-FIXIT_VERSION: str = "0.0.dev6.1"
+FIXIT_VERSION: str = "0.0.dev7"


### PR DESCRIPTION
0.0.dev6.1 invalid version number. [PEP440](https://www.python.org/dev/peps/pep-0440/)
Replace with 0.0.dev7