### PR TITLE
[doc] remove duplicated class docstring and use class name as rule name

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -213,13 +213,10 @@ def setup(app):
     app.connect("autodoc-process-signature", strip_class_signature)
     app.connect("autodoc-process-docstring", strip_class_signature_docstring)
     app.add_css_file("custom.css")
-    import sys
+    from fixit.common.document import create_rule_doc
     from pathlib import Path
 
-    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-    from docs.source.lib import create_rule_doc
-
-    create_rule_doc()
+    create_rule_doc(Path(__file__).parent / "rules")
 
 
 nbsphinx_prolog = r"""

--- a/fixit/common/document.py
+++ b/fixit/common/document.py
@@ -6,7 +6,6 @@
 import difflib
 from pathlib import Path
 from textwrap import dedent, indent
-from typing import IO
 
 from fixit.common.base import LintRuleT
 from fixit.common.config import get_rules_from_config
@@ -16,21 +15,21 @@ def _add_code_indent(code: str) -> str:
     return indent(code, "    ") + "\n"
 
 
-def write_example_cases(fp: IO[str], rule: LintRuleT, key: str) -> None:
-    s = ""
-    doc = rule.__doc__
-    if doc:
-        s += dedent(doc)
-    if hasattr(rule, key):
-        line = f"{key} Code Examples"
-        line_len = len(line)
-        s += dedent(
-            f"""
-            {"-" * line_len}
-            {line}
-            {"-" * line_len}
+def _add_title_style(title: str, symbol: str) -> str:
+    title_length = len(title)
+    return dedent(
+        f"""
+            {symbol * title_length}
+            {title}
+            {symbol * title_length}
             """
-        )
+    )
+
+
+def gen_example_cases(rule: LintRuleT, key: str) -> str:
+    s = ""
+    if hasattr(rule, key):
+        s += _add_title_style(f"{key} Code Examples", "-")
         for idx, example in enumerate(getattr(rule, key)):
             source = dedent(example.code)
             s += dedent(
@@ -61,34 +60,18 @@ def write_example_cases(fp: IO[str], rule: LintRuleT, key: str) -> None:
                     """
                 )
                 s += _add_code_indent(diff)
-    fp.write(s)
+    return s
 
 
-def _get_dashed_rule_name_from_camel_case(name: str) -> str:
-    """E.g. convert "ClsInClassmethodRule" as "cls-in-classmethod". """
-    rule_name = "".join(f"-{i.lower()}" if i.isupper() else i for i in name).lstrip("-")
-    post_fix_to_remove = "-rule"
-    if rule_name.endswith(post_fix_to_remove):
-        rule_name = rule_name[: -len(post_fix_to_remove)]
-    return rule_name
-
-
-def create_rule_doc() -> None:
-    directory = Path(__file__).parent / "rules"
+def create_rule_doc(directory: Path) -> None:
     directory.mkdir(exist_ok=True)
 
     for rule in get_rules_from_config():
-        rule_name = _get_dashed_rule_name_from_camel_case(rule.__name__)
-        rule_name_len = len(rule_name)
+        rule_name = rule.__name__
         with (directory / f"{rule_name}.rst").open("w") as fp:
-            fp.write(
-                dedent(
-                    f"""\
-                    {"=" * rule_name_len}
-                    {rule_name}
-                    {"=" * rule_name_len}
-                    """
-                )
-            )
-            write_example_cases(fp, rule, "VALID")
-            write_example_cases(fp, rule, "INVALID")
+            fp.write(_add_title_style(rule_name, "="))
+            doc = rule.__doc__
+            if doc:
+                fp.write(dedent(doc))
+            fp.write(gen_example_cases(rule, "VALID"))
+            fp.write(gen_example_cases(rule, "INVALID"))


### PR DESCRIPTION
1. remove duplicated class docstring.
2. use class name as rule name.

Before:
![image](https://user-images.githubusercontent.com/3840867/90804794-9094cd00-e2cf-11ea-8cfa-ced4dbdf5d50.png)


After:
![image](https://user-images.githubusercontent.com/3840867/90804290-d8672480-e2ce-11ea-862a-abb92804b049.png)
