### PR TITLE
[docs] add has autofix, message, version and Josie as an author

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,12 +24,15 @@
 
 # -- Project information -----------------------------------------------------
 
+from fixit._version import FIXIT_VERSION
+
+
 project = "Fixit"
 copyright = "2020, Facebook"
-author = "Jimmy Lai, Tim Hatch, John Reese, Benjamin Woodruff"
+author = "Jimmy Lai, Josie Eshkenazi, Tim Hatch, John Reese, Benjamin Woodruff"
 
 # The short X.Y version
-version = ""
+version = FIXIT_VERSION
 # The full version, including alpha/beta/rc tags
 release = ""
 

--- a/fixit/common/document.py
+++ b/fixit/common/document.py
@@ -63,6 +63,11 @@ def gen_example_cases(rule: LintRuleT, key: str) -> str:
     return s
 
 
+def _has_autofix(rule: LintRuleT) -> bool:
+    invalids = getattr(rule, "INVALID", [])
+    return any(i.expected_replacement for i in invalids)
+
+
 def create_rule_doc(directory: Path) -> None:
     directory.mkdir(exist_ok=True)
 
@@ -71,7 +76,16 @@ def create_rule_doc(directory: Path) -> None:
         with (directory / f"{rule_name}.rst").open("w") as fp:
             fp.write(_add_title_style(rule_name, "="))
             doc = rule.__doc__
-            if doc:
+            if doc is not None:
                 fp.write(dedent(doc))
+            message = getattr(rule, "MESSAGE", None)
+            if message is not None:
+                fp.write(_add_title_style("Message", "-"))
+                fp.write(message + "\n")
+            fp.write(
+                _add_title_style(
+                    f"Has Autofix: {'Yes' if _has_autofix(rule) else 'No'}", "-"
+                )
+            )
             fp.write(gen_example_cases(rule, "VALID"))
             fp.write(gen_example_cases(rule, "INVALID"))


### PR DESCRIPTION
Add `Message` and `Has Autofix` to lint rule doc.

Use the FIXIT_VERSION variable to show the current version in the generated doc.

![image](https://user-images.githubusercontent.com/3840867/90816554-4f0d1d80-e2e1-11ea-842f-35104b486c26.png)
