### PR TITLE
[doc] fold example when more than 3, add logo in doc, upgrade Flake8

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.toggle {
+    display: block;
+    clear: both;
+    margin-bottom: 24px;
+}
+
+.toggle:after {
+    content: "Show More Examples [+]";
+}
+
+.toggle.open:before {
+    content: "Hide Examples [-]";
+}
+.toggle.open:after {
+    content: "";
+}

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -1,0 +1,14 @@
+{% extends "!page.html" %}
+
+{% block footer %}
+ <script type="text/javascript">
+    $(document).ready(function() {
+        $(".toggle > *").hide();
+        $(".toggle").show();
+        $(".toggle").click(function() {
+            $(this).children().toggle(200);
+            $(this).toggleClass("open");
+        })
+    });
+</script>
+{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,8 +111,8 @@ html_static_path = ["_static"]
 #
 # html_sidebars = {}
 
-html_logo = "_static/logo/horizontal_white_sidebar.png"
-html_favicon = "_static/logo/favicon.ico"
+html_logo = "_static/logo/logo_whilte.png"
+html_favicon = "_static/logo/icon.png"
 
 # -- Options for HTMLHelp output ---------------------------------------------
 
@@ -219,7 +219,7 @@ def setup(app):
     from fixit.common.document import create_rule_doc
     from pathlib import Path
 
-    create_rule_doc(Path(__file__).parent / "rules")
+    create_rule_doc(Path(__file__).parent / "rules", to_fold_examples=True)
 
 
 nbsphinx_prolog = r"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flake8==3.8.1
+flake8==3.8.3
 libcst==0.3.6
 pyyaml==5.2


### PR DESCRIPTION
1. Add white logo and color favicon to the doc.
2. "Show More Examples" when there are more than 3 examples.
![image](https://user-images.githubusercontent.com/3840867/90835539-c05cc880-e301-11ea-8e74-95a956e50617.png)


After click on the "Show More Examples", it shows example and becomes "Hide Examples"
![image](https://user-images.githubusercontent.com/3840867/90835595-e4b8a500-e301-11ea-8243-16306f70db72.png)

Click "Hide Examples" to fold the examples again.

Those change keep the lint rule page shorter because some rules have too many examples.