### PR TITLE
[doc] run unittest command in tutorial

### DIFF
--- a/docs/source/test_a_lint_rule.ipynb
+++ b/docs/source/test_a_lint_rule.ipynb
@@ -164,7 +164,7 @@
     "=========\n",
     "\n",
     "Fixit provides :func:`~fixit.common.testing.add_lint_rule_tests_to_module` to automatically generate `unittest <https://docs.python.org/3/library/unittest.html>`_ test cases in a module.\n",
-    "If you're contribute a new lint rule to Fixit, you can add the rule in ``fixit/rules/`` of fixit repository.\n",
+    "If you're contributing a new lint rule to Fixit, you can add the rule in ``fixit/rules/`` of fixit repository.\n",
     "The :func:`~fixit.common.testing.add_lint_rule_tests_to_module` is already configured in ``fixit/tests/__init__.py``.\n",
     "Run the added tests by:"
    ]
@@ -184,7 +184,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "In you're developing a custom lint rule in your codebase, you can configure :func:`~fixit.common.testing.add_lint_rule_tests_to_module` in your test module \n",
+    "If you're developing a custom lint rule in your codebase, you can configure :func:`~fixit.common.testing.add_lint_rule_tests_to_module` in your test module \n",
     "by passing `globals()` as the `module_attrs` argument and providing a set of the rules you would like to test as the `rules` argument.\n",
     "E.g. ``add_lint_rule_tests_to_module(globals(), {my_package.Rule1, my_package.Rule2})``\n",
     "Then run your test module by::\n",


### PR DESCRIPTION
## Summary
Run unittest command in tutorial to make the tutorial more robust.

## Test Plan
tox -e docs

![image](https://user-images.githubusercontent.com/3840867/91235037-7bfa6f80-e6e9-11ea-8607-9276b6030b2a.png)
