### PR TITLE
Upgrade LibCST to 0.3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flake8==3.8.3
-libcst==0.3.6
-pyyaml==5.2
+flake8>=3.8.3
+libcst>=0.3.10
+pyyaml>=5.2

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     package_data={"fixit": ["py.typed"]},
     test_suite="fixit",
     python_requires=">=3.6",
-    install_requires=["flake8 >= 3.7.9", "libcst >= 0.3.3", "pyyaml >= 5.2",],
+    install_requires=[dep.strip() for dep in open("requirements.txt").readlines()],
     extras_require={
         "dev": [
             "black",


### PR DESCRIPTION
## Summary
1. Upgrade LibCST to 0.3.10
2. Use `requirements.txt` as source of required dependency in `setup.py`.

## Test Plan
Existing tests.
