### PR TITLE
Show detailed Pyre error to make it more clear

### DIFF
--- a/fixit/cli/full_repo_metadata.py
+++ b/fixit/cli/full_repo_metadata.py
@@ -30,14 +30,14 @@ class MetadataCacheErrorHandler(Handler):
         # see https://docs.python.org/3.8/library/logging.html#logrecord-objects
         exc_info = record.exc_info
         if exc_info is not None:
-            exc_type = exc_info[0]
+            exc_type, exc_msg = exc_info[0], exc_info[1]
             failed_paths = record.__dict__.get("paths")
             if exc_type is not None:
                 # Store exceptions in memory for processing later.
                 if exc_type is TimeoutExpired:
                     self.timeout_paths += failed_paths
                 else:
-                    self.other_exceptions[exc_type] += failed_paths
+                    self.other_exceptions[f"{exc_type}: {exc_msg}"] += failed_paths
 
 
 def get_metadata_caches(

--- a/fixit/common/full_repo_metadata.py
+++ b/fixit/common/full_repo_metadata.py
@@ -62,13 +62,13 @@ def get_repo_caches(
         )
         try:
             frm.resolve_cache()
-        except Exception:
+        except Exception as e:
             # We want to fail silently since some metadata providers can be flaky. If a logger is provided by the caller, we'll add a log here.
             logger = config.logger
             if logger is not None:
                 logger.warning(
                     "Failed to retrieve metadata cache.",
-                    exc_info=True,
+                    exc_info=e,
                     extra={"paths": paths_batch},
                 )
             # Populate with placeholder caches to avoid failures down the line. This will however result in reduced functionality in cache-dependent lint rules.


### PR DESCRIPTION
## Summary
Show detailed Pyre error to make it more clear

Before:
```
Encountered exception <class 'Exception'>:  for the following paths:
./example.py
Running `pyre start` may solve the issue.
```

After:
```
Encountered exception <class 'Exception'>: 'response'
stderr:
 2020-08-26 11:37:25,937 DEBUG Running /Users/jimmylai/github/fixit-env/bin/pyre.bin query types(path='example.py') -log-directory /private/var/folders/x4/bhcx83kj41l6jpcp8cl9lzww0000gn/T/tmpm4anuhx0/.pyre .
2020-08-26 11:37:25,942 DEBUG Registering process with pid 36887 in pid file /private/var/folders/x4/bhcx83kj41l6jpcp8cl9lzww0000gn/T/tmpm4anuhx0/.pyre/pid_files/query-36887.pid
2020-08-26 11:37:25,982 INFO Connected to server
2020-08-26 11:37:25,982 DEBUG Removing pid file: /private/var/folders/x4/bhcx83kj41l6jpcp8cl9lzww0000gn/T/tmpm4anuhx0/.pyre/pid_files/query-36887.pid
stdout:
 {"error":"Not able to get lookups in: \n\t`/private/var/folders/x4/bhcx83kj41l6jpcp8cl9lzww0000gn/T/tmpm4anuhx0/example.py`"}
 for the following paths:
./example.py
Running pyre start may solve the issue.
```
