### PR TITLE
Relative to repo root

### DIFF
--- a/fixit/cli/args.py
+++ b/fixit/cli/args.py
@@ -128,9 +128,10 @@ def get_paths_parser() -> argparse.ArgumentParser:
         type=relative_to_repo_root,
         default=(Path(get_lint_config().repo_root),),
         help=(
-            "The name of a directory (e.g. media) or file (e.g. media/views.py) on "
-            + "which to run the script. If not specified, the lint rule is run on the"
-            + " `repo_root` specified in the `fixit.config.yaml` file."
+            "The name of a directory (e.g. media) or file (e.g. media/views.py) "
+            + "relative to the `repo_root` specified in the `fixit.config.yaml` file"
+            + " on which to run this script. "
+            + "If not specified, the `repo_root` value is used."
         ),
     )
     return parser


### PR DESCRIPTION
## Summary
- It's an antipattern to allow linting of files outside of the repository where fixit is installed
- We will enforce it in the argument parser that is used in all the cli scripts

## Test Plan
- All scripts work as before
- when a path outside of the repo is passed, error looks like:
![image](https://user-images.githubusercontent.com/22413721/91350441-b4b34b00-e7b4-11ea-9c6c-a8cc077bae70.png)

