### PR TITLE
[CI] remove duplicated coverage job from each platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,16 +70,12 @@ jobs:
         run: |
           python -m pip install tox
           tox --version
-      - name: Test
-        run: |
-          tox -e $(python .github/scripts/tox_job.py)
       - name: Lint
         run: |
           tox -e lint
-      - name: Coverage
+      - name: Test
         run: |
-          tox -e coverage
-        continue-on-error: true
+          tox -e $(python .github/scripts/tox_job.py)
 
   pyre:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
Remove duplicated coverage job from each platform.

We already have a separate coverage job run on ubuntu, Py3.8 which is good enough for collecting code coverage data.
https://github.com/Instagram/Fixit/blob/master/.github/workflows/build.yml#L109-L138

Also move lint job to run before tests.

## Test Plan
CI builds.
