### PR TITLE
export common helpers in fixit for easier imports

### DIFF
--- a/docs/source/build_a_lint_rule.ipynb
+++ b/docs/source/build_a_lint_rule.ipynb
@@ -68,7 +68,7 @@
     "\n",
     "Lint Rule Scaffolding\n",
     "=====================\n",
-    "A lint rule is a subclass of :class:`~fixit.common.base.CstLintRule` which inherits from `CSTVisitor` in LibCST.\n",
+    "A lint rule is a subclass of :class:`~fixit.CstLintRule` which inherits from `CSTVisitor` in LibCST.\n",
     "LibCST provides `visitors <https://libcst.readthedocs.io/en/latest/tutorial.html#Build-Visitor-or-Transformer>`_ for traversing the syntax tree.\n",
     "Defining a ``visit_`` or ``leave_`` functions for a specific types of `CSTNode <https://libcst.readthedocs.io/en/latest/nodes.html>`_ allows us to register a callback function to be called during the syntax tree traversal.\n",
     "\n",
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fixit.common.base import CstLintRule\n",
+    "from fixit import CstLintRule\n",
     "import libcst as cst\n",
     "\n",
     "\n",
@@ -187,7 +187,7 @@
     "\n",
     "Reporting Violations\n",
     "====================\n",
-    "To report a lint violation, simply call :func:`~fixit.common.base.CstLintRule.report` with a CSTNode.\n",
+    "To report a lint violation, simply call :func:`~fixit.CstLintRule.report` with a CSTNode.\n",
     "Define a lint message via the ``MESSAGE`` attribute in your lint class.\n",
     "Keep your lint descriptions brief but informative. Link to other documentation if you want to provide an extended explanation. Feedback that you provide to a developer should be clear and actionable.\n",
     "Add a docstring to the rule class to provide more context and the docstring will be included in the generated document."
@@ -269,7 +269,7 @@
     "==============\n",
     "Certain behaviors may be acceptable in certain types of files, but not in others.\n",
     "We can avoid running the linter on some files by overriding should_skip_file.\n",
-    "The properties provided by ``self.context`` (:func:`~fixit.base.common.BaseContext`) are useful when implementing :func:`~fixit.base.common.CstLintRule.should_skip_file`."
+    "The properties provided by ``self.context`` (:func:`~fixit.common.base.BaseContext`) are useful when implementing :func:`~fixit.base.common.CstLintRule.should_skip_file`."
    ]
   },
   {
@@ -300,9 +300,9 @@
     "Reference\n",
     "=========\n",
     "\n",
-    ".. autoclass:: fixit.common.base.CstLintRule\n",
+    ".. autoclass:: fixit.CstLintRule\n",
     ".. autoclass:: fixit.common.base.BaseContext\n",
-    ".. autoclass:: fixit.common.base.CstContext"
+    ".. autoclass:: fixit.CstContext"
    ]
   }
  ],

--- a/docs/source/test_a_lint_rule.ipynb
+++ b/docs/source/test_a_lint_rule.ipynb
@@ -40,8 +40,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fixit.common.base import CstLintRule\n",
-    "from fixit.common.utils import (\n",
+    "from fixit import (\n",
+    "    CstLintRule,\n",
     "    InvalidTestCase as Invalid,\n",
     "    ValidTestCase as Valid,\n",
     ")\n",
@@ -59,7 +59,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "Valid test cases are defined using :class:`~fixit.common.utils.ValidTestCase` (imported as a shorter name ``Valid``), and invalid test cases are defined using :class:`~fixit.common.utils.InvalidTestCase` (imported as a shorter name ``Invalid``).\n",
+    "Valid test cases are defined using :class:`~fixit.ValidTestCase` (imported as a shorter name ``Valid``), and invalid test cases are defined using :class:`~fixit.InvalidTestCase` (imported as a shorter name ``Invalid``).\n",
     "You should add test cases until all potential edge-cases are covered.\n"
    ]
   },
@@ -163,9 +163,9 @@
     "Run Tests\n",
     "=========\n",
     "\n",
-    "Fixit provides :func:`~fixit.common.testing.add_lint_rule_tests_to_module` to automatically generate `unittest <https://docs.python.org/3/library/unittest.html>`_ test cases in a module.\n",
+    "Fixit provides :func:`~fixit.add_lint_rule_tests_to_module` to automatically generate `unittest <https://docs.python.org/3/library/unittest.html>`_ test cases in a module.\n",
     "If you're contributing a new lint rule to Fixit, you can add the rule in ``fixit/rules/`` of fixit repository.\n",
-    "The :func:`~fixit.common.testing.add_lint_rule_tests_to_module` is already configured in ``fixit/tests/__init__.py``.\n",
+    "The :func:`~fixit.add_lint_rule_tests_to_module` is already configured in ``fixit/tests/__init__.py``.\n",
     "Run the added tests by:"
    ]
   },
@@ -184,7 +184,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "If you're developing a custom lint rule in your codebase, you can configure :func:`~fixit.common.testing.add_lint_rule_tests_to_module` in your test module \n",
+    "If you're developing a custom lint rule in your codebase, you can configure :func:`~fixit.add_lint_rule_tests_to_module` in your test module \n",
     "by passing `globals()` as the `module_attrs` argument and providing a set of the rules you would like to test as the `rules` argument.\n",
     "E.g. ``add_lint_rule_tests_to_module(globals(), {my_package.Rule1, my_package.Rule2})``\n",
     "Then run your test module by::\n",
@@ -198,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fixit.common.testing import add_lint_rule_tests_to_module\n",
+    "from fixit import add_lint_rule_tests_to_module\n",
     "\n",
     "add_lint_rule_tests_to_module(globals(), rules=[NoInheritFromObjectRule])\n",
     "import unittest\n",
@@ -237,9 +237,9 @@
     "Reference\n",
     "=========\n",
     "\n",
-    ".. autoclass:: fixit.common.utils.ValidTestCase\n",
-    ".. autoclass:: fixit.common.utils.InvalidTestCase\n",
-    ".. autofunction:: fixit.common.testing.add_lint_rule_tests_to_module"
+    ".. autoclass:: fixit.ValidTestCase\n",
+    ".. autoclass:: fixit.InvalidTestCase\n",
+    ".. autofunction:: fixit.add_lint_rule_tests_to_module"
    ]
   }
  ],

--- a/fixit/__init__.py
+++ b/fixit/__init__.py
@@ -2,3 +2,19 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
+from fixit.common.base import CstContext, CstLintRule, LintConfig
+from fixit.common.report import CstLintRuleReport
+from fixit.common.testing import add_lint_rule_tests_to_module
+from fixit.common.utils import InvalidTestCase, ValidTestCase
+
+
+__all__ = [
+    "CstContext",
+    "CstLintRule",
+    "LintConfig",
+    "ValidTestCase",
+    "InvalidTestCase",
+    "CstLintRuleReport",
+    "add_lint_rule_tests_to_module",
+]

--- a/fixit/rules/avoid_or_in_except.py
+++ b/fixit/rules/avoid_or_in_except.py
@@ -6,8 +6,7 @@
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class AvoidOrInExceptRule(CstLintRule):

--- a/fixit/rules/await_async_call.py
+++ b/fixit/rules/await_async_call.py
@@ -10,8 +10,7 @@ import libcst.matchers as m
 from libcst.helpers import get_full_name_for_node
 from libcst.metadata import TypeInferenceProvider
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class AwaitAsyncCallRule(CstLintRule):

--- a/fixit/rules/cls_in_classmethod.py
+++ b/fixit/rules/cls_in_classmethod.py
@@ -14,8 +14,7 @@ from libcst.metadata import (
     ScopeProvider,
 )
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 CLS = "cls"

--- a/fixit/rules/compare_primitives_by_equal.py
+++ b/fixit/rules/compare_primitives_by_equal.py
@@ -5,8 +5,7 @@
 
 import libcst as cst
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class ComparePrimitivesByEqualRule(CstLintRule):

--- a/fixit/rules/compare_singleton_primitives_by_is.py
+++ b/fixit/rules/compare_singleton_primitives_by_is.py
@@ -8,8 +8,7 @@ from typing import FrozenSet, Union
 import libcst as cst
 from libcst.metadata import QualifiedName, QualifiedNameProvider, QualifiedNameSource
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class CompareSingletonPrimitivesByIsRule(CstLintRule):

--- a/fixit/rules/gather_sequential_await.py
+++ b/fixit/rules/gather_sequential_await.py
@@ -5,8 +5,7 @@
 
 import libcst as cst
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class GatherSequentialAwaitRule(CstLintRule):

--- a/fixit/rules/import_constraints.py
+++ b/fixit/rules/import_constraints.py
@@ -12,8 +12,13 @@ from typing import Dict, Iterable, List, Optional, Sequence, Set
 import libcst as cst
 from libcst.helpers import get_full_name_for_node_or_raise
 
-from fixit.common.base import CstContext, CstLintRule, LintConfig
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import (
+    CstContext,
+    CstLintRule,
+    InvalidTestCase as Invalid,
+    LintConfig,
+    ValidTestCase as Valid,
+)
 
 
 TEST_REPO_ROOT: str = str(Path(__file__).parent.parent)
@@ -111,27 +116,27 @@ def _get_local_roots(repo_root: Path) -> Set[str]:
 class ImportConstraintsRule(CstLintRule):
     """
     Rule to impose import constraints in certain directories to improve runtime performance.
-    The directories specified in the ImportConstraintsRule setting in the `.fixit.config.yaml` file's
-    `rule_config` section can impose import constraints for that directory and its children as follows:
+    The directories specified in the ImportConstraintsRule setting in the ``.fixit.config.yaml`` file's
+    ``rule_config`` section can impose import constraints for that directory and its children as follows::
 
-    rule_config:
-        ImportConstraintsRule:
-            dir_under_repo_root:
-                rules: [
-                    ["module_under_repo_root", "allow"],
-                    ["another_module_under_repo_root, "deny"],
-                    ["*", "deny"]
-                ]
-                ignore_tests: True
-                ignore_types: True
+        rule_config:
+            ImportConstraintsRule:
+                dir_under_repo_root:
+                    rules: [
+                        ["module_under_repo_root", "allow"],
+                        ["another_module_under_repo_root, "deny"],
+                        ["*", "deny"]
+                    ]
+                    ignore_tests: True
+                    ignore_types: True
 
-    Each rule under `rules` is evaluated in order from top to bottom and the last rule for each directory
+    Each rule under ``rules`` is evaluated in order from top to bottom and the last rule for each directory
     should be a wildcard rule.
-    `ignore_tests` and `ignore_types` should carry boolean values and can be omitted. They are both set to
+    ``ignore_tests`` and `ignore_types` should carry boolean values and can be omitted. They are both set to
     `True` by default.
-    If `ignore_types` is True, this rule will ignore imports inside `if TYPE_CHECKING` blocks since those
+    If ``ignore_types`` is True, this rule will ignore imports inside ``if TYPE_CHECKING`` blocks since those
     imports do not have an affect on runtime performance.
-    If `ignore_tests` is True, this rule will not lint any files found in a testing module.
+    If ``ignore_tests`` is True, this rule will not lint any files found in a testing module.
     """
 
     _config: Optional[_ImportConfig]

--- a/fixit/rules/no_assert_equals.py
+++ b/fixit/rules/no_assert_equals.py
@@ -6,8 +6,7 @@
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class NoAssertEqualsRule(CstLintRule):

--- a/fixit/rules/no_implicit_concat.py
+++ b/fixit/rules/no_implicit_concat.py
@@ -7,8 +7,7 @@ from typing import List
 
 import libcst as cst
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class UsePlusForStringConcatRule(CstLintRule):

--- a/fixit/rules/no_inherit_from_object.py
+++ b/fixit/rules/no_inherit_from_object.py
@@ -6,8 +6,7 @@
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class NoInheritFromObjectRule(CstLintRule):

--- a/fixit/rules/no_static_if_condition.py
+++ b/fixit/rules/no_static_if_condition.py
@@ -8,8 +8,7 @@ from typing import Optional
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class NoStaticIfConditionRule(CstLintRule):

--- a/fixit/rules/replace_union_with_optional.py
+++ b/fixit/rules/replace_union_with_optional.py
@@ -6,8 +6,12 @@
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstContext, CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import (
+    CstContext,
+    CstLintRule,
+    InvalidTestCase as Invalid,
+    ValidTestCase as Valid,
+)
 
 
 class ReplaceUnionWithOptionalRule(CstLintRule):

--- a/fixit/rules/rewrite_to_comprehension.py
+++ b/fixit/rules/rewrite_to_comprehension.py
@@ -6,8 +6,7 @@
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 UNNECESSARY_GENERATOR: str = (

--- a/fixit/rules/rewrite_to_literal.py
+++ b/fixit/rules/rewrite_to_literal.py
@@ -6,8 +6,7 @@
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 UNNECESSARY_LITERAL: str = (

--- a/fixit/rules/unnecessary_list_comprehension.py
+++ b/fixit/rules/unnecessary_list_comprehension.py
@@ -6,8 +6,7 @@
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 UNNECESSARY_LIST_COMPREHENSION: str = (

--- a/fixit/rules/use_classname_as_code.py
+++ b/fixit/rules/use_classname_as_code.py
@@ -9,8 +9,12 @@ from typing import cast
 import libcst as cst
 import libcst.matchers as m
 
-from fixit.common.base import CstContext, CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import (
+    CstContext,
+    CstLintRule,
+    InvalidTestCase as Invalid,
+    ValidTestCase as Valid,
+)
 
 
 class UseClassNameAsCodeRule(CstLintRule):

--- a/fixit/rules/use_is_none_on_optional.py
+++ b/fixit/rules/use_is_none_on_optional.py
@@ -9,9 +9,8 @@ import libcst as cst
 import libcst.matchers as m
 from libcst.metadata import TypeInferenceProvider
 
-from fixit.common.base import CstLintRule
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 from fixit.common.report import CstLintRuleReport
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class UseIsNoneOnOptionalRule(CstLintRule):

--- a/fixit/rules/use_types_from_typing.py
+++ b/fixit/rules/use_types_from_typing.py
@@ -8,8 +8,12 @@ from typing import Set
 import libcst
 from libcst.metadata import ScopeProvider
 
-from fixit.common.base import CstContext, CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import (
+    CstContext,
+    CstLintRule,
+    InvalidTestCase as Invalid,
+    ValidTestCase as Valid,
+)
 
 
 REPLACE_BUILTIN_TYPE_ANNOTATION: str = (

--- a/fixit/tests/__init__.py
+++ b/fixit/tests/__init__.py
@@ -5,9 +5,9 @@
 
 from pathlib import Path
 
+from fixit import add_lint_rule_tests_to_module
 from fixit.common.base import LintConfig
 from fixit.common.config import get_lint_config, get_rules_from_config
-from fixit.common.testing import add_lint_rule_tests_to_module
 
 
 # Add all the CstLintRules from `fixit.rules` package to this module as unit tests.


### PR DESCRIPTION
## Summary
1. export common helpers (CstLintRule, CstContext, etc) from fixit for usability.
2. update all rules to import from fixit.
3. update tutorials to import from fixit.
4. fix document of ImportConstraintsRule.

Fixes https://github.com/Instagram/Fixit/issues/66

## Test Plan
CI builds.
