### PR TITLE
Use codecov to collect code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,3 +127,5 @@ jobs:
       - name: coverage
         run: |
           tox -e coverage
+      - name: codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,8 +127,3 @@ jobs:
       - name: coverage
         run: |
           tox -e coverage
-      - name: Upload
-        uses: actions/upload-artifact@v2
-        with:
-          name: coverage_report.html
-          path: coverage_report.html

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: no
+    patch: yes

--- a/tox.ini
+++ b/tox.ini
@@ -43,5 +43,4 @@ passenv =
     CIRCLE_*
 commands =
     coverage run setup.py test
-    coverage xml
-    diff-cover coverage.xml --html-report coverage_report.html
+    codecov

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,4 @@ passenv =
     CIRCLE_*
 commands =
     coverage run setup.py test
+    coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -43,4 +43,3 @@ passenv =
     CIRCLE_*
 commands =
     coverage run setup.py test
-    codecov


### PR DESCRIPTION
## Summary
Use codecov to collect code coverage

## Test Plan
CI builds.

https://codecov.io/gh/Instagram/Fixit/pull/105/tree?path=fixit
![image](https://user-images.githubusercontent.com/3840867/92040009-e5eac880-ed2a-11ea-8f1c-f97848ee7ea3.png)
