### PR TITLE
Explain why 2nd test case is valid in GatherSequentialAwaitRule

### DIFF
--- a/fixit/rules/gather_sequential_await.py
+++ b/fixit/rules/gather_sequential_await.py
@@ -24,9 +24,10 @@ class GatherSequentialAwaitRule(CstLintRule):
                 return await async_bar()
             """
         ),
-        # await in a loop is fine if it's a test.
         Valid(
             """
+            # await in a loop is fine if it's a test.
+            # filename="foo/tests/test_foo.py"
             async def async_check_call():
                 for _i in range(0, 2):
                     await async_foo()


### PR DESCRIPTION
In the generated docs (https://fixit.readthedocs.io/en/latest/rules/GatherSequentialAwaitRule.html), the second valid test case looks the same as the first invalid case, which is confusing. Reported by @abesto
