### PR TITLE
Run pyre query initially

### DIFF
--- a/docs/source/getting_started.ipynb
+++ b/docs/source/getting_started.ipynb
@@ -79,7 +79,8 @@
     "fp.close()\n",
     "! pyre start --store-type-check-resolution\n",
     "! git init\n",
-    "! git add example.py"
+    "! git add example.py",
+    "! pyre query \"types(path='example.py')\""
    ]
   },
   {


### PR DESCRIPTION
## Summary
- So we don't get pyre timeout errors in the tutorials, let's run `pyre query` in the background during start up of the notebook. This way we'll have a cache of types

## Test Plan
Docs before: 
![image](https://user-images.githubusercontent.com/22413721/92145779-bc8f7280-ede6-11ea-9c48-01ba10b1fda8.png)
Docs after:
![image](https://user-images.githubusercontent.com/22413721/92145821-c7e29e00-ede6-11ea-8d4c-8d208ea979d9.png)



