### PR TITLE
[doc] add a missing newline

### DIFF
--- a/docs/source/getting_started.ipynb
+++ b/docs/source/getting_started.ipynb
@@ -79,7 +79,7 @@
     "fp.close()\n",
     "! pyre start --store-type-check-resolution\n",
     "! git init\n",
-    "! git add example.py",
+    "! git add example.py\n",
     "! pyre query \"types(path='example.py')\""
    ]
   },


### PR DESCRIPTION
## Summary
Due to the missing newline.
The generated doc doesn't look right.

![image](https://user-images.githubusercontent.com/3840867/92289054-f8e4d080-eec3-11ea-9270-f2b232180af9.png)
https://fixit.readthedocs.io/en/latest/getting_started.html


## Test Plan

![image](https://user-images.githubusercontent.com/3840867/92288973-bb804300-eec3-11ea-9966-663314754fd8.png)
