### PR TITLE
Replace fstring url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 docs/source/rules/
 coverage.xml
 coverage_report.html
+.idea/

--- a/fixit/rules/use_fstring.py
+++ b/fixit/rules/use_fstring.py
@@ -94,7 +94,7 @@ class UseFstringRule(CstLintRule):
     MESSAGE: str = (
         "Do not use printf style formatting or .format(). "
         + "Use f-string instead to be more readable and efficient. "
-        + "See https://fburl.com/usefstring."
+        + "See https://www.python.org/dev/peps/pep-0498/"
     )
 
     VALID = [


### PR DESCRIPTION
## Summary

Fixes #115
* Replaced  https://fburl.com/usefstring -> https://www.python.org/dev/peps/pep-0498/ 
* Added `.idea/` to `.gitignore`

