### PR TITLE
[bug] CollapseIsinstanceChecksRule rewrite elif as if wrongly

### DIFF
--- a/fixit/rules/chained_instance_check.py
+++ b/fixit/rules/chained_instance_check.py
@@ -64,6 +64,21 @@ class CollapseIsinstanceChecksRule(CstLintRule):
     ]
     INVALID = [
         Invalid(
+            """
+            if something:
+                pass
+            elif isinstance(x, y) or isinstance(x, z):
+                pass
+            """,
+            expected_replacement=
+            """
+            if something:
+                pass
+            elif isinstance(x, (y, z)):
+                pass
+            """,
+        ),
+        Invalid(
             "isinstance(x, y) or isinstance(x, z)",
             expected_replacement="isinstance(x, (y, z))",
         ),


### PR DESCRIPTION
## Summary
This is for reproducing a bug of CollapseIsinstanceChecksRule.
It rewrites `elif` as `if` which is wrong.

CC @isidentical 
## Test Plan

`tox -e py37 fixit.tests.CollapseIsinstanceChecksRule`

Output:
```
F....................
======================================================================
FAIL: test_INVALID_0 (fixit.common.testing.CollapseIsinstanceChecksRule)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jimmylai/github/Fixit/fixit/common/testing.py", line 221, in test_method
    return getattr(self, custom_test_method_name)(data, rule, fixture_file)
  File "/Users/jimmylai/github/Fixit/fixit/common/testing.py", line 117, in _test_method
    validate_patch(report, test_case)
  File "/Users/jimmylai/github/Fixit/fixit/common/testing.py", line 48, in validate_patch
    + f"But found:\n{patched_code}"
AssertionError: Auto-fix did not produce expected result.
Expected:
if something:
    pass
elif isinstance(x, (y, z)):
    pass

But found:
if something:
    pass
if isinstance(x, (y, z)):
    pass


----------------------------------------------------------------------
Ran 21 tests in 0.400s
```
