### PR TITLE
Added --name argument 

### DIFF
--- a/docs/source/build_a_lint_rule.ipynb
+++ b/docs/source/build_a_lint_rule.ipynb
@@ -386,3 +386,4 @@
  "nbformat": 4,
  "nbformat_minor": 4
 }
+

--- a/docs/source/build_a_lint_rule.ipynb
+++ b/docs/source/build_a_lint_rule.ipynb
@@ -139,8 +139,8 @@
     "\n",
     "The `fixit.cli.add_new_rule` contains two argument, ``-path`` and ``--name``\n",
     "\n",
-    "- ``--path`` is used to create rule file at path given in ``--path``, Default is ``fixit/rules/new.py``\n",
-    "- ``--name`` is used to assign the name of the rule and should be in snake case, Default is name of the rule file if ``path`` provided else `new`. Otherwise, considers the value specified in ``--name``\n",
+    "- ``--path`` is used to create rule file at path given in ``--path``, defaults to ``fixit/rules/new.py``\n",
+    "- ``--name`` is used to assign the name of the rule and should be in snake case, defaults to the rule file name if ``path`` provided else `new`. Otherwise, considers the value specified in ``--name``\n",
     "\n",
     "Please provide the name of the rule in snake case without the suffix ``rule`` as CLI will take care of adding ``Rule`` to end of the rule name. \n"
    ]
@@ -386,4 +386,3 @@
  "nbformat": 4,
  "nbformat_minor": 4
 }
-

--- a/docs/source/build_a_lint_rule.ipynb
+++ b/docs/source/build_a_lint_rule.ipynb
@@ -132,17 +132,17 @@
     "\n",
     "Use fixit's cli to generate a skeleton of adding a new rule file::\n",
     "\n",
-    "    $ python -m fixit.cli.add_new_rule # Creates new_rule.py at fixit/rules/new_rule.py\n",
-    "    $ python -m fixit.cli.add_new_rule --path fixit/rules/my_rule.py --name rule_name # Creates rule file at path specified \n",
+    "    $ python -m fixit.cli.add_new_rule # Creates new.py at fixit/rules/new.py\n",
+    "    $ python -m fixit.cli.add_new_rule --path fixit/rules/my_rule.py --name rule_name # Creates my_rule.py at path specified \n",
     "\n",
     "This will generate a rule file used to create and add new rule to fixit module. \n",
     "\n",
     "The `fixit.cli.add_new_rule` contains two argument, ``-path`` and ``--name``\n",
     "\n",
-    "- ``--path`` is used to create rule file at path given in ``--path``\n",
-    "- ``--name`` is used to assign the name of the rule and should be in snake case\n",
+    "- ``--path`` is used to create rule file at path given in ``--path``, Default is ``fixit/rules/new.py``\n",
+    "- ``--name`` is used to assign the name of the rule and should be in snake case, Default is name of the rule file if ``path`` provided else `new`. Otherwise, considers the value specified in ``--name``\n",
     "\n",
-    "Please provide the name of the rule in snake case without the suffix ``rule`` as CLI will take care of adding ``Rule`` to end of the rule name\n"
+    "Please provide the name of the rule in snake case without the suffix ``rule`` as CLI will take care of adding ``Rule`` to end of the rule name. \n"
    ]
   },
   {

--- a/docs/source/build_a_lint_rule.ipynb
+++ b/docs/source/build_a_lint_rule.ipynb
@@ -133,9 +133,16 @@
     "Use fixit's cli to generate a skeleton of adding a new rule file::\n",
     "\n",
     "    $ python -m fixit.cli.add_new_rule # Creates new_rule.py at fixit/rules/new_rule.py\n",
-    "    $ python -m fixit.cli.add_new_rule --path fixit/rules/my_rule.py # Creates rule file at path specified\n",
+    "    $ python -m fixit.cli.add_new_rule --path fixit/rules/my_rule.py --name rule_name # Creates rule file at path specified \n",
     "\n",
-    "This will generate a rule file used to create and add new rule to fixit module."
+    "This will generate a rule file used to create and add new rule to fixit module. \n",
+    "\n",
+    "The `fixit.cli.add_new_rule` contains two argument, ``-path`` and ``--name``\n",
+    "\n",
+    "- ``--path`` is used to create rule file at path given in ``--path``\n",
+    "- ``--name`` is used to assign the name of the rule and should be in snake case\n",
+    "\n",
+    "Please provide the name of the rule in snake case without the suffix ``rule`` as CLI will take care of adding ``Rule`` to end of the rule name\n"
    ]
   },
   {
@@ -160,7 +167,7 @@
    },
    "outputs": [],
    "source": [
-    "! python3 -m fixit.cli.add_new_rule --path fixit/rules/my_rule.py"
+    "! python -m fixit.cli.add_new_rule --path fixit/rules/my_rule.py --name abcd"
    ]
   },
   {
@@ -178,7 +185,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "Now, you can add rule's functionality on top of above generated file. \n",
+    "Now, you can add rule's functionality on top of above generated file. Also, make sure to check the class name in generated file. Your class name should always be suffixed with ``Rule``.\n",
     "\n",
     "The Declarative Matcher API\n",
     "===========================\n",
@@ -373,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -94,8 +94,8 @@ def main() -> None:
         "-p",
         "--path",
         type=is_path_exists,
-        default=Path("fixit/rules/new_rule.py"),
-        help="Path to add rule file, Default is fixit/rules/new_rule.py",
+        default=Path("fixit/rules/new.py"),
+        help="Path to add rule file, Default is fixit/rules/new.py",
     )
 
     parser.add_argument(
@@ -103,7 +103,7 @@ def main() -> None:
         "--name",
         type=str,
         default="",
-        help="Name of the rule, Default is Rule",
+        help="Name of the rule, Default is New",
     )
 
     args = parser.parse_args()

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -95,7 +95,7 @@ def main() -> None:
         "--path",
         type=is_path_exists,
         default=Path("fixit/rules/new.py"),
-        help="Path to add rule file, Default is fixit/rules/new.py",
+        help="Path to add rule file, defaults to fixit/rules/new.py",
     )
 
     parser.add_argument(
@@ -103,7 +103,7 @@ def main() -> None:
         "--name",
         type=str,
         default="",
-        help="Name of the rule, Default is New",
+        help="Name of the rule, defaults to `New`",
     )
 
     args = parser.parse_args()

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -67,13 +67,14 @@ def is_path_exists(path: str) -> Path:
 
 def is_valid_name(name: str) -> str:
     """Check for valid rule name """
-    if name.endswith(("Rule", "Rules", "rule", "rules")):
-        raise NameError("Please enter rule name without the suffix, `rule` or `Rule`")
-    return snake_to_camelcase(name) if name else ""
+    if name.casefold().endswith(("rule", "rules")):
+        raise ValueError("Please enter rule name without the suffix, 'rule' or 'Rule'")
+    return snake_to_camelcase(name)
 
 
 def create_rule_file(file_path: Path, rule_name: str) -> None:
     """Create a new rule file."""
+    rule_name = is_valid_name(rule_name)
     context = _LICENCE + _IMPORTS + _TO_DOS + _RULE_CLASS
     updated_context = invoke_formatter(
         get_lint_config().formatter, context.format(class_name=rule_name)
@@ -100,13 +101,16 @@ def main() -> None:
     parser.add_argument(
         "-n",
         "--name",
-        type=is_valid_name,
+        type=str,
         default="",
         help="Name of the rule, Default is Rule",
     )
 
     args = parser.parse_args()
-    create_rule_file(args.path, args.name)
+
+    file_path = args.path
+    rule_name = args.name if args.name else file_path.stem
+    create_rule_file(file_path, rule_name)
 
 
 if __name__ == "__main__":

--- a/fixit/cli/utils.py
+++ b/fixit/cli/utils.py
@@ -22,3 +22,8 @@ def print_cyan(message: str) -> None:
 
 def print_red(message: str) -> None:
     print_color(91, message)
+
+
+def snake_to_camelcase(name: str) -> str:
+    """Convert snake-case string to camel-case string."""
+    return "".join(n.capitalize() for n in name.split("_"))


### PR DESCRIPTION
## Summary
Refer #119
* Added `--name` argument to fixit's add_new_rule CLI
`python -m fixit.cli.add_new_rule --path fixit/rules/my_rule.py --name abcd`

`--file` = `fixit/rules/my_rule.py`
`--name` = `abcd`

The file will be created at `fixit/rules/my_rule.py` with class name  `abcd` as `AbcdRule` 

```python
class AbcdRule(CstLintRule):
    """
    docstring or new_rule description
    """

    MESSAGE = "Enter rule description message"

    VALID = [Valid("'example'")]

    INVALID = [Invalid("'example'")]

```
* Added `snake_to_camelcase` function to `fixit/cli/utils.py`
* Added documentation to `docs/source/build_a_lint_rule.ipynb`

## Test Plan

