### PR TITLE
[testing] print test case when an Invalid test fails for easier debug

### DIFF
--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -88,7 +88,8 @@ class LintRuleTestCase(unittest.TestCase):
                 len(reports),
                 0,
                 'Expected a report for this "invalid" test case but `self.report` was '
-                + 'not called:\n' + test_case.code,
+                + "not called:\n"
+                + test_case.code,
             )
             self.assertLessEqual(
                 len(reports),

--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -87,7 +87,8 @@ class LintRuleTestCase(unittest.TestCase):
             self.assertGreater(
                 len(reports),
                 0,
-                'Expected a report for this "invalid" test case. `self.report` was not called.',
+                'Expected a report for this "invalid" test case but `self.report` was '
+                + 'not called:\n' + test_case.code,
             )
             self.assertLessEqual(
                 len(reports),


### PR DESCRIPTION
## Summary

Without this change, developer needs to use the test case count (3 for INVALID_3) to figure out which test case fails. It's not convenient when the rule has lots of test cases.
```
FAIL: test_INVALID_3 (fixit.common.testing.NoRedundantLambdaRule)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jimmylai/github/Fixit/fixit/common/testing.py", line 221, in test_method
    return getattr(self, custom_test_method_name)(data, rule, fixture_file)
  File "/Users/jimmylai/github/Fixit/fixit/common/testing.py", line 90, in _test_method
    'Expected a report for this "invalid" test case. `self.report` was not called.',
AssertionError: 0 not greater than 0 : Expected a report for this "invalid" test case. `self.report` was not called.
```

With this change, the failed test case source code is included to make it more clear.
```
FAIL: test_INVALID_3 (fixit.common.testing.NoRedundantLambdaRule)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jimmylai/github/Fixit/fixit/common/testing.py", line 222, in test_method
    return getattr(self, custom_test_method_name)(data, rule, fixture_file)
  File "/Users/jimmylai/github/Fixit/fixit/common/testing.py", line 91, in _test_method
    + 'not called:\n' + test_case.code,
AssertionError: 0 not greater than 0 : Expected a report for this "invalid" test case but `self.report` was not called:
lambda x: fun()
```


## Test Plan
See the above.
