### PR TITLE
Add UseAssertIsNotNoneRule

### DIFF
--- a/fixit/common/tests/test_imports.py
+++ b/fixit/common/tests/test_imports.py
@@ -58,7 +58,7 @@ class ImportsTest(UnitTest):
 
         # Test with an existing dummy rule.
         imported_rule = import_rule_from_package(rules_package[0], "DummyRule2")
-        self.assertTrue(imported_rule is not None)
+        self.assertIsNotNone(imported_rule)
         self.assertEqual(imported_rule.__name__, "DummyRule2")
         self.assertEqual(imported_rule.__module__, f"{DUMMY_PACKAGE}.dummy_2")
 

--- a/fixit/rules/use_assert_is_not_none.py
+++ b/fixit/rules/use_assert_is_not_none.py
@@ -65,10 +65,6 @@ class UseAssertIsNotNoneRule(CstLintRule):
     ]
 
     def visit_Call(self, node: cst.Call) -> None:
-        found_match = False
-        new_cst_attr = None
-        new_node_arg = None
-
         # `self.assertTrue(x is not None)` -> `self.assertIsNotNone(x)`
         if m.matches(
             node,
@@ -85,9 +81,14 @@ class UseAssertIsNotNoneRule(CstLintRule):
                 ],
             ),
         ):
-            found_match = True
-            new_node_arg = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
-            new_cst_attr = "assertIsNotNone"
+            new_call = node.with_changes(
+                func=cst.Attribute(
+                    value=cst.Name("self"), attr=cst.Name("assertIsNotNone")
+                ),
+                args=[cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)],
+            )
+            self.report(node, replacement=new_call)
+
         # `self.assertFalse(x is None)` -> `self.assertIsNotNone(x)`
         elif m.matches(
             node,
@@ -104,9 +105,13 @@ class UseAssertIsNotNoneRule(CstLintRule):
                 ],
             ),
         ):
-            found_match = True
-            new_node_arg = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
-            new_cst_attr = "assertIsNotNone"
+            new_call = node.with_changes(
+                func=cst.Attribute(
+                    value=cst.Name("self"), attr=cst.Name("assertIsNotNone")
+                ),
+                args=[cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)],
+            )
+            self.report(node, replacement=new_call)
         # `self.assertTrue(x is None)` -> `self.assertIsNotNone(x))
         elif m.matches(
             node,
@@ -123,9 +128,13 @@ class UseAssertIsNotNoneRule(CstLintRule):
                 ],
             ),
         ):
-            found_match = True
-            new_node_arg = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
-            new_cst_attr = "assertIsNone"
+            new_call = node.with_changes(
+                func=cst.Attribute(
+                    value=cst.Name("self"), attr=cst.Name("assertIsNone")
+                ),
+                args=[cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)],
+            )
+            self.report(node, replacement=new_call)
 
         # `self.assertFalse(x is not None)` -> `self.assertIsNone(x)`
         elif m.matches(
@@ -143,13 +152,10 @@ class UseAssertIsNotNoneRule(CstLintRule):
                 ],
             ),
         ):
-            found_match = True
-            new_node_arg = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
-            new_cst_attr = "assertIsNone"
-
-        if found_match:
             new_call = node.with_changes(
-                func=cst.Attribute(value=cst.Name("self"), attr=cst.Name(new_cst_attr)),
-                args=[new_node_arg],
+                func=cst.Attribute(
+                    value=cst.Name("self"), attr=cst.Name("assertIsNone")
+                ),
+                args=[cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)],
             )
             self.report(node, replacement=new_call)

--- a/fixit/rules/use_assert_is_not_none.py
+++ b/fixit/rules/use_assert_is_not_none.py
@@ -1,0 +1,71 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.helpers import ensure_type
+
+from fixit.common.base import CstLintRule
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+
+
+class UseAssertIsNotNoneRule(CstLintRule):
+    """
+    Discourages use of ``assertTrue(x is not None)`` as it is deprecated (https://docs.python.org/2/library/unittest.html#deprecated-aliases).
+    Use ``assertIsNotNone(x)`` instead.
+
+    """
+
+    MESSAGE: str = (
+        '"assertTrue" is deprecated. Use "assertIsNotNone" instead.\n'
+        + "See https://docs.python.org/2/library/unittest.html#deprecated-aliases"
+    )
+
+    VALID = [
+        Valid("self.assertTrue(x is None)"),
+        Valid("self.assertTrue(not x is None)"),
+        Valid("self.assertTrue(x)"),
+    ]
+
+    INVALID = [
+        Invalid(
+            "self.assertTrue(a is not None)",
+            expected_replacement="self.assertIsNotNone(a)",
+        ),
+        Invalid(
+            "self.assertTrue(f() is not None)",
+            expected_replacement="self.assertIsNotNone(f())",
+        ),
+        Invalid(
+            "self.assertTrue(f(x) is not None)",
+            expected_replacement="self.assertIsNotNone(f(x))",
+        ),
+    ]
+
+    def visit_Call(self, node: cst.Call) -> None:
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(value=m.Name("self"), attr=m.Name("assertTrue")),
+                args=[
+                    m.Arg(
+                        m.Comparison(
+                            comparisons=[
+                                m.ComparisonTarget(m.IsNot(), comparator=m.Name("None"))
+                            ]
+                        )
+                    )
+                ],
+            ),
+        ):
+            arg1 = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
+
+            new_call = node.with_changes(
+                func=cst.Attribute(
+                    value=cst.Name("self"), attr=cst.Name("assertIsNotNone")
+                ),
+                args=[arg1],
+            )
+            self.report(node, replacement=new_call)

--- a/fixit/rules/use_assert_is_not_none.py
+++ b/fixit/rules/use_assert_is_not_none.py
@@ -13,20 +13,21 @@ from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Vali
 
 class UseAssertIsNotNoneRule(CstLintRule):
     """
-    Discourages use of ``assertTrue(x is not None)`` as it is deprecated (https://docs.python.org/2/library/unittest.html#deprecated-aliases).
-    Use ``assertIsNotNone(x)`` instead.
+    Discourages use of ``assertTrue(x is not None)`` and ``assertFalse(x is not None)`` as it is deprecated (https://docs.python.org/3.8/library/unittest.html#deprecated-aliases).
+    Use ``assertIsNotNone(x)`` and ``assertIsNone(x)``) instead.
 
     """
 
     MESSAGE: str = (
-        '"assertTrue" is deprecated. Use "assertIsNotNone" instead.\n'
-        + "See https://docs.python.org/2/library/unittest.html#deprecated-aliases"
+        '"assertTrue" and "assertFalse" are deprecated. Use "assertIsNotNone" and "assertIsNone" instead.\n'
+        + "See https://docs.python.org/3.8/library/unittest.html#deprecated-aliases"
     )
 
     VALID = [
-        Valid("self.assertTrue(x is None)"),
         Valid("self.assertTrue(not x is None)"),
         Valid("self.assertTrue(x)"),
+        Valid("self.assertFalse(not x is None)"),
+        Valid("self.assertFalse(x)"),
     ]
 
     INVALID = [
@@ -42,9 +43,29 @@ class UseAssertIsNotNoneRule(CstLintRule):
             "self.assertTrue(f(x) is not None)",
             expected_replacement="self.assertIsNotNone(f(x))",
         ),
+        Invalid(
+            "self.assertTrue(x is None)", expected_replacement="self.assertIsNone(x)"
+        ),
+        Invalid(
+            "self.assertFalse(x is not None)",
+            expected_replacement="self.assertIsNone(x)",
+        ),
+        Invalid(
+            "self.assertFalse(f() is not None)",
+            expected_replacement="self.assertIsNone(f())",
+        ),
+        Invalid(
+            "self.assertFalse(f(x) is not None)",
+            expected_replacement="self.assertIsNone(f(x))",
+        ),
     ]
 
     def visit_Call(self, node: cst.Call) -> None:
+        found_match: bool = False
+        new_cst_attr: Optional[str] = None
+        new_node_arg: Optional[cst.Arg] = None
+
+        # `self.assertTrue(x is not None)` -> `self.assertIsNotNone(x)`
         if m.matches(
             node,
             m.Call(
@@ -60,12 +81,71 @@ class UseAssertIsNotNoneRule(CstLintRule):
                 ],
             ),
         ):
-            arg1 = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
+            found_match = True
+            new_node_arg = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
+            new_cst_attr = "assertIsNotNone"
+        # `self.assertFalse(x is None)` -> `self.assertIsNotNone(x)`
+        elif m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(value=m.Name("self"), attr=m.Name("assertFalse")),
+                args=[
+                    m.Arg(
+                        m.Comparison(
+                            comparisons=[
+                                m.ComparisonTarget(m.Is(), comparator=m.Name("None"))
+                            ]
+                        )
+                    )
+                ],
+            ),
+        ):
+            found_match = True
+            new_node_arg = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
+            new_cst_attr = "assertIsNotNone"
+        # `self.assertTrue(x is None)` -> `self.assertIsNotNone(x))
+        elif m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(value=m.Name("self"), attr=m.Name("assertTrue")),
+                args=[
+                    m.Arg(
+                        m.Comparison(
+                            comparisons=[
+                                m.ComparisonTarget(m.Is(), comparator=m.Name("None"))
+                            ]
+                        )
+                    )
+                ],
+            ),
+        ):
+            found_match = True
+            new_node_arg = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
+            new_cst_attr = "assertIsNone"
 
+        # `self.assertFalse(x is not None)` -> `self.assertIsNone(x)`
+        elif m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(value=m.Name("self"), attr=m.Name("assertFalse")),
+                args=[
+                    m.Arg(
+                        m.Comparison(
+                            comparisons=[
+                                m.ComparisonTarget(m.IsNot(), comparator=m.Name("None"))
+                            ]
+                        )
+                    )
+                ],
+            ),
+        ):
+            found_match = True
+            new_node_arg = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
+            new_cst_attr = "assertIsNone"
+
+        if found_match:
             new_call = node.with_changes(
-                func=cst.Attribute(
-                    value=cst.Name("self"), attr=cst.Name("assertIsNotNone")
-                ),
-                args=[arg1],
+                func=cst.Attribute(value=cst.Name("self"), attr=cst.Name(new_cst_attr)),
+                args=[new_node_arg],
             )
             self.report(node, replacement=new_call)

--- a/fixit/rules/use_assert_is_not_none.py
+++ b/fixit/rules/use_assert_is_not_none.py
@@ -58,6 +58,10 @@ class UseAssertIsNotNoneRule(CstLintRule):
             "self.assertFalse(f(x) is not None)",
             expected_replacement="self.assertIsNone(f(x))",
         ),
+        Invalid(
+            "self.assertFalse(x is None)",
+            expected_replacement="self.assertIsNotNone(x)",
+        ),
     ]
 
     def visit_Call(self, node: cst.Call) -> None:

--- a/fixit/rules/use_assert_is_not_none.py
+++ b/fixit/rules/use_assert_is_not_none.py
@@ -65,9 +65,9 @@ class UseAssertIsNotNoneRule(CstLintRule):
     ]
 
     def visit_Call(self, node: cst.Call) -> None:
-        found_match: bool = False
-        new_cst_attr: Optional[str] = None
-        new_node_arg: Optional[cst.Arg] = None
+        found_match = False
+        new_cst_attr = None
+        new_node_arg = None
 
         # `self.assertTrue(x is not None)` -> `self.assertIsNotNone(x)`
         if m.matches(

--- a/fixit/rules/use_assert_is_not_none.py
+++ b/fixit/rules/use_assert_is_not_none.py
@@ -128,7 +128,12 @@ class UseAssertIsNotNoneRule(CstLintRule):
                 ),
                 args=[
                     cst.Arg(
-                        ensure_type(node.args[0].value.expression, cst.Comparison).left
+                        ensure_type(
+                            ensure_type(
+                                node.args[0].value, cst.UnaryOperation
+                            ).expression,
+                            cst.Comparison,
+                        ).left
                     )
                 ],
             )
@@ -231,7 +236,12 @@ class UseAssertIsNotNoneRule(CstLintRule):
                 ),
                 args=[
                     cst.Arg(
-                        ensure_type(node.args[0].value.expression, cst.Comparison).left
+                        ensure_type(
+                            ensure_type(
+                                node.args[0].value, cst.UnaryOperation
+                            ).expression,
+                            cst.Comparison,
+                        ).left
                     )
                 ],
             )


### PR DESCRIPTION
## Summary

Adds a lint rule to check for the pattern `self.assertTrue(x is not None)` and corrects to `self.assertIsNotNone(x)`

## Test Plan

`tox -e py38`

```
----------------------------------------------------------------------
Ran 431 tests in 2.378s

OK
____________________________________________ summary ____________________________________________
  py38: commands succeeded
  congratulations :)
```


`tox -e py38 -- fixit.tests.UseAssertIsNotNoneRule`

```
----------------------------------------------------------------------
Ran 6 tests in 0.087s

OK
____________________________________________ summary ____________________________________________
  py38: commands succeeded
  congratulations :)
```

