### PR TITLE
Fixit CLI

### DIFF
--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -111,7 +111,7 @@ def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> N
             description="Creates a skeleton of adding new rule file",
         )
         _add_arguments(add_rule_parser)
-        _main(add_rule_parser.parse_args())
+        sys.exit(_main(add_rule_parser.parse_args()))
 
     else:
         add_rule_parser = parser.add_parser(
@@ -132,4 +132,4 @@ def _main(args: argparse.Namespace) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(register_subparser())
+    register_subparser()

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -11,7 +11,7 @@
 
 import argparse
 from pathlib import Path
-from typing import Union
+from typing import Optional
 
 from libcst.codemod._cli import invoke_formatter
 
@@ -87,9 +87,7 @@ def create_rule_file(file_path: Path, rule_name: str) -> None:
     print(f"Successfully created {file_path.name} rule file at {file_path.parent}")
 
 
-def _add_arguments(
-    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser]
-) -> None:
+def _add_arguments(parser: argparse.ArgumentParser) -> None:
     """All required arguments for `add_new_rule` """
     parser.add_argument(
         "--path",
@@ -105,7 +103,7 @@ def _add_arguments(
     )
 
 
-def register_subparser(parser: argparse._SubParsersAction = None) -> None:
+def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> None:
     """Add parser or subparser for `add_new_rule` command."""
     if parser is None:
         add_rule_parser = argparse.ArgumentParser(

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -11,6 +11,7 @@
 
 import argparse
 from pathlib import Path
+from typing import Union
 
 from libcst.codemod._cli import invoke_formatter
 
@@ -86,57 +87,44 @@ def create_rule_file(file_path: Path, rule_name: str) -> None:
     print(f"Successfully created {file_path.name} rule file at {file_path.parent}")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Creates a skeleton of adding new rule file"
-    )
+def _parser_arguments(
+    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
+    sub_parser: bool = True,
+) -> None:
+    """All required arguments for `add_new_rule` """
     parser.add_argument(
-        "-p",
         "--path",
         type=is_path_exists,
         default=Path("fixit/rules/new.py"),
         help="Path to add rule file, defaults to fixit/rules/new.py",
     )
-
     parser.add_argument(
-        "-n",
         "--name",
         type=str,
         default="",
         help="Name of the rule, defaults to `New`",
     )
 
-    args = parser.parse_args()
+    if sub_parser:
+        parser.set_defaults(subparser_fn=_main)
+    else:
+        _main(parser.parse_args())
 
-    file_path = args.path
-    rule_name = args.name if args.name else file_path.stem
-    create_rule_file(file_path, rule_name)
 
-
-def register_subparser(parsers: argparse._SubParsersAction) -> None:
-    """Add subparser for `add_new_rule` command."""
-    add_new_rule_parser = parsers.add_parser(
-        "add_new_rule",
-        help="Creates a skeleton of adding new rule file.",
-    )
-
-    add_new_rule_parser.add_argument(
-        "-p",
-        "--path",
-        type=is_path_exists,
-        default=Path("fixit/rules/new.py"),
-        help="Path to add rule file, defaults to fixit/rules/new.py",
-    )
-
-    add_new_rule_parser.add_argument(
-        "-n",
-        "--name",
-        type=str,
-        default="",
-        help="Name of the rule, defaults to `New`",
-    )
-
-    add_new_rule_parser.set_defaults(subparser_fn=_main)
+def register_subparser(parser: argparse._SubParsersAction = None) -> None:
+    """Add parser or subparser for `add_new_rule` command."""
+    if parser is None:
+        add_rule_parser = argparse.ArgumentParser(
+            description="Creates a skeleton of adding new rule file",
+        )
+        _parser_arguments(add_rule_parser, sub_parser=False)
+    else:
+        add_rule_parser = parser.add_parser(
+            "add_new_rule",
+            description="Creates a skeleton of adding new rule file.",
+            help="Creates a skeleton of adding new rule file.",
+        )
+        _parser_arguments(add_rule_parser)
 
 
 def _main(args: argparse.Namespace) -> None:
@@ -146,4 +134,4 @@ def _main(args: argparse.Namespace) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    register_subparser()

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -113,5 +113,37 @@ def main() -> None:
     create_rule_file(file_path, rule_name)
 
 
+def register_subparser(parsers: argparse._SubParsersAction) -> None:
+    """Add subparser for `add_new_rule` command."""
+    add_new_rule_parser = parsers.add_parser(
+        "add_new_rule",
+        help="Creates a skeleton of adding new rule file.",
+    )
+
+    add_new_rule_parser.add_argument(
+        "-p",
+        "--path",
+        type=is_path_exists,
+        default=Path("fixit/rules/new.py"),
+        help="Path to add rule file, defaults to fixit/rules/new.py",
+    )
+
+    add_new_rule_parser.add_argument(
+        "-n",
+        "--name",
+        type=str,
+        default="",
+        help="Name of the rule, defaults to `New`",
+    )
+
+    add_new_rule_parser.set_defaults(subparser_fn=_main)
+
+
+def _main(args: argparse.Namespace):
+    file_path = args.path
+    rule_name = args.name if args.name else file_path.stem
+    create_rule_file(file_path, rule_name)
+
+
 if __name__ == "__main__":
     main()

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -87,9 +87,8 @@ def create_rule_file(file_path: Path, rule_name: str) -> None:
     print(f"Successfully created {file_path.name} rule file at {file_path.parent}")
 
 
-def _parser_arguments(
-    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
-    sub_parser: bool = True,
+def _add_arguments(
+    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser]
 ) -> None:
     """All required arguments for `add_new_rule` """
     parser.add_argument(
@@ -105,11 +104,6 @@ def _parser_arguments(
         help="Name of the rule, defaults to `New`",
     )
 
-    if sub_parser:
-        parser.set_defaults(subparser_fn=_main)
-    else:
-        _main(parser.parse_args())
-
 
 def register_subparser(parser: argparse._SubParsersAction = None) -> None:
     """Add parser or subparser for `add_new_rule` command."""
@@ -117,14 +111,17 @@ def register_subparser(parser: argparse._SubParsersAction = None) -> None:
         add_rule_parser = argparse.ArgumentParser(
             description="Creates a skeleton of adding new rule file",
         )
-        _parser_arguments(add_rule_parser, sub_parser=False)
+        _add_arguments(add_rule_parser)
+        _main(add_rule_parser.parse_args())
+
     else:
         add_rule_parser = parser.add_parser(
             "add_new_rule",
             description="Creates a skeleton of adding new rule file.",
             help="Creates a skeleton of adding new rule file.",
         )
-        _parser_arguments(add_rule_parser)
+        _add_arguments(add_rule_parser)
+        add_rule_parser.set_defaults(subparser_fn=_main)
 
 
 def _main(args: argparse.Namespace) -> None:

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -139,7 +139,7 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:
     add_new_rule_parser.set_defaults(subparser_fn=_main)
 
 
-def _main(args: argparse.Namespace):
+def _main(args: argparse.Namespace) -> None:
     file_path = args.path
     rule_name = args.name if args.name else file_path.stem
     create_rule_file(file_path, rule_name)

--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -10,6 +10,7 @@
 #   $ python -m fixit.cli.add_new_rule --path fixit/rules/new_rule.py --name rule_name
 
 import argparse
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -122,11 +123,13 @@ def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> N
         add_rule_parser.set_defaults(subparser_fn=_main)
 
 
-def _main(args: argparse.Namespace) -> None:
+def _main(args: argparse.Namespace) -> int:
     file_path = args.path
     rule_name = args.name if args.name else file_path.stem
     create_rule_file(file_path, rule_name)
 
+    return 0
+
 
 if __name__ == "__main__":
-    register_subparser()
+    sys.exit(register_subparser())

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -12,6 +12,7 @@
 import argparse
 import itertools
 import shutil
+import sys
 import time
 from dataclasses import dataclass
 from multiprocessing import Manager
@@ -230,7 +231,7 @@ def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> N
         apply_fix_parser.set_defaults(subparser_fn=_main)
 
 
-def _main(args: argparse.Namespace) -> None:
+def _main(args: argparse.Namespace) -> int:
     width = shutil.get_terminal_size(fallback=(80, 24)).columns
 
     rules = args.rules
@@ -310,6 +311,8 @@ def _main(args: argparse.Namespace) -> None:
             + f"{time.time() - start_time :.2f} seconds."
         )
 
+    return 0
+
 
 if __name__ == "__main__":
-    register_subparser()
+    sys.exit(register_subparser())

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -203,15 +203,12 @@ def call_map_paths_and_print_reports(
     return num_reports
 
 
-def _parser_arguments(
-    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
-    sub_parser: bool = True,
+def _add_arguments(
+    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser]
 ) -> None:
     """All required arguments for `apply_fix`"""
-    if sub_parser:
-        parser.set_defaults(subparser_fn=_main)
-    else:
-        _main(parser.parse_args())
+    # Add arguments for `apply fix`
+    pass
 
 
 def register_subparser(parser: argparse._SubParsersAction = None) -> None:
@@ -221,7 +218,8 @@ def register_subparser(parser: argparse._SubParsersAction = None) -> None:
             description=DESCRIPTION,
             parents=PARENTS,
         )
-        _parser_arguments(apply_fix_parser, sub_parser=False)
+        _add_arguments(apply_fix_parser)
+        _main(apply_fix_parser.parse_args())
 
     else:
         apply_fix_parser = parser.add_parser(
@@ -230,7 +228,8 @@ def register_subparser(parser: argparse._SubParsersAction = None) -> None:
             parents=PARENTS,
             help="Apply lint rule fix(s)",
         )
-        _parser_arguments(apply_fix_parser)
+        _add_arguments(apply_fix_parser)
+        apply_fix_parser.set_defaults(subparser_fn=_main)
 
 
 def _main(args: argparse.Namespace) -> None:

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -54,12 +54,12 @@ if TYPE_CHECKING:
 
 MAX_ITER: int = 100
 
-DESCRIPTION = """Runs a lint rule's autofixer over all of over a set of files or
+DESCRIPTION: str = """Runs a lint rule's autofixer over all of over a set of files or
 directories. This is similar to the functionality provided by LibCST codemods
 (https://libcst.readthedocs.io/en/latest/codemods_tutorial.html), but limited to the
 small subset of APIs provided by Fixit."""
 
-PARENTS = [
+PARENTS: List[argparse.ArgumentParser] = [
     get_rules_parser(),
     get_metadata_cache_parser(),
     get_paths_parser(),

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -8,15 +8,15 @@
 #   $ python -m fixit.cli.apply_fix --help
 #   $ python -m fixit.cli.apply_fix --rules AvoidOrInExceptRule
 #   $ python -m fixit.cli.apply_fix . --rules AvoidOrInExceptRule
+
 import argparse
 import itertools
 import shutil
-import sys
 import time
 from dataclasses import dataclass
 from multiprocessing import Manager
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Union
 
 from libcst import ParserSyntaxError, parse_module
 from libcst.codemod._cli import invoke_formatter
@@ -53,6 +53,22 @@ if TYPE_CHECKING:
     from libcst.metadata.base_provider import ProviderT
 
 MAX_ITER: int = 100
+
+DESCRIPTION = """Runs a lint rule's autofixer over all of over a set of files or
+directories. This is similar to the functionality provided by LibCST codemods
+(https://libcst.readthedocs.io/en/latest/codemods_tutorial.html), but limited to the
+small subset of APIs provided by Fixit."""
+
+PARENTS = [
+    get_rules_parser(),
+    get_metadata_cache_parser(),
+    get_paths_parser(),
+    get_skip_ignore_comments_parser(),
+    get_skip_ignore_byte_marker_parser(),
+    get_skip_autoformatter_parser(),
+    get_compact_parser(),
+    get_multiprocessing_parser(),
+]
 
 
 @dataclass(frozen=True)
@@ -187,137 +203,34 @@ def call_map_paths_and_print_reports(
     return num_reports
 
 
-def main(raw_args: Sequence[str]) -> int:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Runs a lint rule's autofixer over all of over a set of "
-            + "files or directories.\n"
-            + "\n"
-            + "This is similar to the functionality provided by LibCST codemods "
-            + "(https://libcst.readthedocs.io/en/latest/codemods_tutorial.html), "
-            + "but limited to the small subset of APIs provided by Fixit."
-        ),
-        parents=[
-            get_rules_parser(),
-            get_metadata_cache_parser(),
-            get_paths_parser(),
-            get_skip_ignore_comments_parser(),
-            get_skip_ignore_byte_marker_parser(),
-            get_skip_autoformatter_parser(),
-            get_compact_parser(),
-            get_multiprocessing_parser(),
-        ],
-    )
+def _parser_arguments(
+    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
+    sub_parser: bool = True,
+) -> None:
+    """All required arguments for `apply_fix`"""
+    if sub_parser:
+        parser.set_defaults(subparser_fn=_main)
+    else:
+        _main(parser.parse_args())
 
-    args = parser.parse_args(raw_args)
-    width = shutil.get_terminal_size(fallback=(80, 24)).columns
 
-    rules = args.rules
-    use_ignore_byte_markers = args.use_ignore_byte_markers
-    use_ignore_comments = args.use_ignore_comments
-    skip_autoformatter = args.skip_autoformatter
-    formatter = AutofixingLintRuleReportFormatter(width, args.compact)
-    workers = args.workers
-
-    # Find files if directory was provided.
-    file_paths = tuple(find_files(args.paths))
-
-    if not args.compact:
-        print(f"Scanning {len(file_paths)} files")
-        print("\n".join(file_paths))
-        print()
-    start_time = time.time()
-
-    total_reports_count = 0
-
-    if rules_require_metadata_cache(rules):
-        touched_files = set()
-        next_files = file_paths
-        with Manager() as manager:
-            # Avoid getting stuck in an infinite loop.
-            for _ in range(MAX_ITER):
-                if not next_files:
-                    break
-
-                patched_files = manager.list()
-                metadata_caches = get_metadata_caches(args.cache_timeout, next_files)
-
-                next_files = []
-                # opts is a more type-safe version of args that we pass around
-                opts = LintOpts(
-                    rules=rules,
-                    use_ignore_byte_markers=use_ignore_byte_markers,
-                    use_ignore_comments=use_ignore_comments,
-                    skip_autoformatter=skip_autoformatter,
-                    formatter=formatter,
-                    patched_files_list=patched_files,
-                )
-                total_reports_count += call_map_paths_and_print_reports(
-                    next_files, opts, workers, metadata_caches
-                )
-                next_files = list(patched_files)
-                touched_files.update(patched_files)
-
-        # Finally, format all the touched files.
-        if not skip_autoformatter:
-            for path in touched_files:
-                with open(path, "rb") as f:
-                    source = f.read()
-                # Format the code using the config file's formatter.
-                formatted_source = invoke_formatter(get_lint_config().formatter, source)
-                with open(path, "wb") as f:
-                    f.write(formatted_source)
+def register_subparser(parser: argparse._SubParsersAction = None) -> None:
+    """Add parser or subparser for `apply_fix` command."""
+    if parser is None:
+        apply_fix_parser = argparse.ArgumentParser(
+            description=DESCRIPTION,
+            parents=PARENTS,
+        )
+        _parser_arguments(apply_fix_parser, sub_parser=False)
 
     else:
-        # opts is a more type-safe version of args that we pass around
-        opts = LintOpts(
-            rules=rules,
-            use_ignore_byte_markers=use_ignore_byte_markers,
-            use_ignore_comments=use_ignore_comments,
-            skip_autoformatter=skip_autoformatter,
-            formatter=formatter,
+        apply_fix_parser = parser.add_parser(
+            "apply_fix",
+            description=DESCRIPTION,
+            parents=PARENTS,
+            help="Apply lint rule fix(s)",
         )
-
-        total_reports_count = call_map_paths_and_print_reports(
-            file_paths, opts, workers, None
-        )
-
-    if not args.compact:
-        print()
-        print(
-            f"Found {total_reports_count} reports in {len(file_paths)} files in "
-            + f"{time.time() - start_time :.2f} seconds."
-        )
-
-    return 0
-
-
-def register_subparser(parsers: argparse._SubParsersAction) -> None:
-    """Add subparser for `apply_fix` command."""
-    apply_fix_parser = parsers.add_parser(
-        "apply_fix",
-        description=(
-            "Runs a lint rule's autofixer over all of over a set of "
-            + "files or directories.\n"
-            + "\n"
-            + "This is similar to the functionality provided by LibCST codemods "
-            + "(https://libcst.readthedocs.io/en/latest/codemods_tutorial.html), "
-            + "but limited to the small subset of APIs provided by Fixit."
-        ),
-        help="Apply lint rule fix(s)",
-        parents=[
-            get_rules_parser(),
-            get_metadata_cache_parser(),
-            get_paths_parser(),
-            get_skip_ignore_comments_parser(),
-            get_skip_ignore_byte_marker_parser(),
-            get_skip_autoformatter_parser(),
-            get_compact_parser(),
-            get_multiprocessing_parser(),
-        ],
-    )
-
-    apply_fix_parser.set_defaults(subparser_fn=_main)
+        _parser_arguments(apply_fix_parser)
 
 
 def _main(args: argparse.Namespace) -> None:
@@ -402,4 +315,4 @@ def _main(args: argparse.Namespace) -> None:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    register_subparser()

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -320,7 +320,7 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:
     apply_fix_parser.set_defaults(subparser_fn=_main)
 
 
-def _main(args: argparse.Namespace):
+def _main(args: argparse.Namespace) -> None:
     width = shutil.get_terminal_size(fallback=(80, 24)).columns
 
     rules = args.rules
@@ -399,8 +399,6 @@ def _main(args: argparse.Namespace):
             f"Found {total_reports_count} reports in {len(file_paths)} files in "
             + f"{time.time() - start_time :.2f} seconds."
         )
-
-    return 0
 
 
 if __name__ == "__main__":

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -16,7 +16,7 @@ import time
 from dataclasses import dataclass
 from multiprocessing import Manager
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional
 
 from libcst import ParserSyntaxError, parse_module
 from libcst.codemod._cli import invoke_formatter
@@ -203,15 +203,13 @@ def call_map_paths_and_print_reports(
     return num_reports
 
 
-def _add_arguments(
-    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser]
-) -> None:
+def _add_arguments(parser: argparse.ArgumentParser) -> None:
     """All required arguments for `apply_fix`"""
     # Add arguments for `apply fix`
     pass
 
 
-def register_subparser(parser: argparse._SubParsersAction = None) -> None:
+def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> None:
     """Add parser or subparser for `apply_fix` command."""
     if parser is None:
         apply_fix_parser = argparse.ArgumentParser(

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -218,7 +218,7 @@ def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> N
             parents=PARENTS,
         )
         _add_arguments(apply_fix_parser)
-        _main(apply_fix_parser.parse_args())
+        sys.exit(_main(apply_fix_parser.parse_args()))
 
     else:
         apply_fix_parser = parser.add_parser(
@@ -315,4 +315,4 @@ def _main(args: argparse.Namespace) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(register_subparser())
+    register_subparser()

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -142,9 +142,8 @@ def get_formatted_reports_for_path(
     return [opts.formatter.format(rr) for rr in raw_reports]
 
 
-def _parser_arguments(
-    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
-    sub_parser: bool = True,
+def _add_arguments(
+    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser]
 ) -> None:
     """All required arguments for `insert_supressions`"""
     parser.add_argument(
@@ -174,11 +173,6 @@ def _parser_arguments(
         help="The maximum number of lines a comment can span before getting truncated",
     )
 
-    if sub_parser:
-        parser.set_defaults(subparser_fn=_main)
-    else:
-        _main(parser.parse_args())
-
 
 def register_subparser(parser: argparse._SubParsersAction = None) -> None:
     """Add parser or subparser for `insert_supressions` command."""
@@ -186,7 +180,8 @@ def register_subparser(parser: argparse._SubParsersAction = None) -> None:
         insert_supressions_parser = argparse.ArgumentParser(
             description=DESCRIPTION, parents=PARENTS
         )
-        _parser_arguments(insert_supressions_parser, sub_parser=False)
+        _add_arguments(insert_supressions_parser)
+        _main(insert_supressions_parser.parse_args())
 
     else:
         insert_supressions_parser = parser.add_parser(
@@ -195,7 +190,8 @@ def register_subparser(parser: argparse._SubParsersAction = None) -> None:
             parents=PARENTS,
             help="Insert comments where violations are found",
         )
-        _parser_arguments(insert_supressions_parser)
+        _add_arguments(insert_supressions_parser)
+        insert_supressions_parser.set_defaults(subparser_fn=_main)
 
 
 def _main(args: argparse.Namespace) -> None:

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -16,7 +16,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Union
 
 from libcst import ParserSyntaxError, parse_module
 from libcst.codemod._cli import invoke_formatter
@@ -51,11 +51,11 @@ from fixit.rule_lint_engine import lint_file
 if TYPE_CHECKING:
     from libcst.metadata.base_provider import ProviderT
 
-DESCRIPTION = """Inserts `# lint-fixme` comments into a file where lint violations are
-found. You should only use this tool if it's not feasible to fix the existing
+DESCRIPTION: str = """Inserts `# lint-fixme` comments into a file where lint violations
+are found. You should only use this tool if it's not feasible to fix the existing
 violations."""
 
-PARENTS = [
+PARENTS: List[argparse.ArgumentParser] = [
     get_rule_parser(),
     get_paths_parser(),
     get_skip_autoformatter_parser(),

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -142,9 +142,7 @@ def get_formatted_reports_for_path(
     return [opts.formatter.format(rr) for rr in raw_reports]
 
 
-def _add_arguments(
-    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser]
-) -> None:
+def _add_arguments(parser: argparse.ArgumentParser) -> None:
     """All required arguments for `insert_supressions`"""
     parser.add_argument(
         "--kind",
@@ -174,7 +172,7 @@ def _add_arguments(
     )
 
 
-def register_subparser(parser: argparse._SubParsersAction = None) -> None:
+def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> None:
     """Add parser or subparser for `insert_supressions` command."""
     if parser is None:
         insert_supressions_parser = argparse.ArgumentParser(

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -180,7 +180,7 @@ def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> N
             description=DESCRIPTION, parents=PARENTS
         )
         _add_arguments(insert_supressions_parser)
-        _main(insert_supressions_parser.parse_args())
+        sys.exit(_main(insert_supressions_parser.parse_args()))
 
     else:
         insert_supressions_parser = parser.add_parser(
@@ -254,4 +254,4 @@ def _main(args: argparse.Namespace) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(register_subparser())
+    register_subparser()

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -8,15 +8,15 @@
 #   $ python -m fixit.cli.insert_suppressions --help
 #   $ python -m fixit.cli.insert_suppressions fixit.rules.avoid_or_in_except.AvoidOrInExceptRule
 #   $ python -m fixit.cli.insert_suppressions fixit.rules.avoid_or_in_except.AvoidOrInExceptRule .
+
 import argparse
 import itertools
 import shutil
-import sys
 import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Union
 
 from libcst import ParserSyntaxError, parse_module
 from libcst.codemod._cli import invoke_formatter
@@ -50,6 +50,19 @@ from fixit.rule_lint_engine import lint_file
 
 if TYPE_CHECKING:
     from libcst.metadata.base_provider import ProviderT
+
+DESCRIPTION = """Inserts `# lint-fixme` comments into a file where lint violations are
+found. You should only use this tool if it's not feasible to fix the existing
+violations."""
+
+PARENTS = [
+    get_rule_parser(),
+    get_paths_parser(),
+    get_skip_autoformatter_parser(),
+    get_compact_parser(),
+    get_metadata_cache_parser(),
+    get_multiprocessing_parser(),
+]
 
 
 class MessageKind(Enum):
@@ -129,24 +142,11 @@ def get_formatted_reports_for_path(
     return [opts.formatter.format(rr) for rr in raw_reports]
 
 
-def main(raw_args: Sequence[str]) -> int:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Inserts `# lint-fixme` comments into a file where lint violations are "
-            + "found.\n"
-            + "\n"
-            + "You should only use this tool if it's not feasible to fix the existing "
-            + "violations."
-        ),
-        parents=[
-            get_rule_parser(),
-            get_paths_parser(),
-            get_skip_autoformatter_parser(),
-            get_compact_parser(),
-            get_metadata_cache_parser(),
-            get_multiprocessing_parser(),
-        ],
-    )
+def _parser_arguments(
+    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
+    sub_parser: bool = True,
+) -> None:
+    """All required arguments for `insert_supressions`"""
     parser.add_argument(
         "--kind",
         default="fixme",
@@ -174,115 +174,28 @@ def main(raw_args: Sequence[str]) -> int:
         help="The maximum number of lines a comment can span before getting truncated",
     )
 
-    args = parser.parse_args(raw_args)
-    width = shutil.get_terminal_size(fallback=(80, 24)).columns
-
-    # Find files if directory was provided.
-    file_paths = tuple(find_files((str(p) for p in args.paths)))
-
-    if not args.compact:
-        print(f"Scanning {len(file_paths)} files")
-        print()
-    start_time = time.time()
-
-    if args.no_message:
-        message = MessageKind.NO_MESSAGE
-    elif args.message is not None:
-        message = args.message
+    if sub_parser:
+        parser.set_defaults(subparser_fn=_main)
     else:
-        message = MessageKind.USE_LINT_REPORT
+        _main(parser.parse_args())
 
-    metadata_caches: Optional[Mapping[str, Mapping["ProviderT", object]]] = None
-    if rules_require_metadata_cache({args.rule}):
-        metadata_caches = get_metadata_caches(args.cache_timeout, file_paths)
 
-    # opts is a more type-safe version of args that we pass around
-    opts = InsertSuppressionsOpts(
-        rule=args.rule,
-        skip_autoformatter=args.skip_autoformatter,
-        kind=SuppressionCommentKind[args.kind.upper()],
-        message=message,
-        max_lines=args.max_lines,
-        formatter=SuppressedLintRuleReportFormatter(width, args.compact),
-    )
-
-    formatted_reports_iter = itertools.chain.from_iterable(
-        map_paths(
-            get_formatted_reports_for_path,
-            file_paths,
-            opts,
-            workers=args.workers,
-            metadata_caches=metadata_caches,
+def register_subparser(parser: argparse._SubParsersAction = None) -> None:
+    """Add parser or subparser for `insert_supressions` command."""
+    if parser is None:
+        insert_supressions_parser = argparse.ArgumentParser(
+            description=DESCRIPTION, parents=PARENTS
         )
-    )
+        _parser_arguments(insert_supressions_parser, sub_parser=False)
 
-    formatted_reports = []
-    for formatted_report in formatted_reports_iter:
-        # Reports are yielded as soon as they're available. Stream the output to the
-        # terminal.
-        print(formatted_report)
-        # save the report from the iterator for later use
-        formatted_reports.append(formatted_report)
-
-    if not args.compact:
-        print()
-        print(
-            f"Found {len(formatted_reports)} reports in {len(file_paths)} files in "
-            + f"{time.time() - start_time :.2f} seconds."
+    else:
+        insert_supressions_parser = parser.add_parser(
+            "insert_suppressions",
+            description=DESCRIPTION,
+            parents=PARENTS,
+            help="Insert comments where violations are found",
         )
-    return 0
-
-
-def register_subparser(parsers: argparse._SubParsersAction) -> None:
-    """Add subparser for `insert_supressions` command."""
-    insert_supressions_parser = parsers.add_parser(
-        "insert_suppressions",
-        description=(
-            "Inserts `# lint-fixme` comments into a file where lint violations are "
-            + "found.\n"
-            + "\n"
-            + "You should only use this tool if it's not feasible to fix the existing "
-            + "violations."
-        ),
-        help="Insert comments where violations are found",
-        parents=[
-            get_rule_parser(),
-            get_paths_parser(),
-            get_skip_autoformatter_parser(),
-            get_compact_parser(),
-            get_metadata_cache_parser(),
-            get_multiprocessing_parser(),
-        ],
-    )
-
-    insert_supressions_parser.add_argument(
-        "--kind",
-        default="fixme",
-        choices=[kind.name.lower() for kind in SuppressionCommentKind],
-        help="Should we use `# lint-fixme` or `# lint-ignore`? Defaults to 'fixme'.",
-    )
-    message_group = insert_supressions_parser.add_mutually_exclusive_group()
-    message_group.add_argument(
-        "--message",
-        default=None,
-        help="Overrides the lint message used in the fixme comment.",
-    )
-    message_group.add_argument(
-        "--no-message",
-        action="store_true",
-        help=(
-            "Don't include a message with the suppression comment. Only include the "
-            + "lint code."
-        ),
-    )
-    insert_supressions_parser.add_argument(
-        "--max-lines",
-        default=3,
-        type=int,
-        help="The maximum number of lines a comment can span before getting truncated",
-    )
-
-    insert_supressions_parser.set_defaults(subparser_fn=_main)
+        _parser_arguments(insert_supressions_parser)
 
 
 def _main(args: argparse.Namespace) -> None:
@@ -344,4 +257,4 @@ def _main(args: argparse.Namespace) -> None:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    register_subparser()

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -285,7 +285,7 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:
     insert_supressions_parser.set_defaults(subparser_fn=_main)
 
 
-def _main(args: argparse.Namespace):
+def _main(args: argparse.Namespace) -> None:
     width = shutil.get_terminal_size(fallback=(80, 24)).columns
 
     # Find files if directory was provided.
@@ -341,7 +341,6 @@ def _main(args: argparse.Namespace):
             f"Found {len(formatted_reports)} reports in {len(file_paths)} files in "
             + f"{time.time() - start_time :.2f} seconds."
         )
-    return 0
 
 
 if __name__ == "__main__":

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -12,6 +12,7 @@
 import argparse
 import itertools
 import shutil
+import sys
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -192,7 +193,7 @@ def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> N
         insert_supressions_parser.set_defaults(subparser_fn=_main)
 
 
-def _main(args: argparse.Namespace) -> None:
+def _main(args: argparse.Namespace) -> int:
     width = shutil.get_terminal_size(fallback=(80, 24)).columns
 
     # Find files if directory was provided.
@@ -249,6 +250,8 @@ def _main(args: argparse.Namespace) -> None:
             + f"{time.time() - start_time :.2f} seconds."
         )
 
+    return 0
+
 
 if __name__ == "__main__":
-    register_subparser()
+    sys.exit(register_subparser())

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -233,5 +233,116 @@ def main(raw_args: Sequence[str]) -> int:
     return 0
 
 
+def register_subparser(parsers: argparse._SubParsersAction) -> None:
+    """Add subparser for `insert_supressions` command."""
+    insert_supressions_parser = parsers.add_parser(
+        "insert_suppressions",
+        description=(
+            "Inserts `# lint-fixme` comments into a file where lint violations are "
+            + "found.\n"
+            + "\n"
+            + "You should only use this tool if it's not feasible to fix the existing "
+            + "violations."
+        ),
+        help="Insert comments where violations are found",
+        parents=[
+            get_rule_parser(),
+            get_paths_parser(),
+            get_skip_autoformatter_parser(),
+            get_compact_parser(),
+            get_metadata_cache_parser(),
+            get_multiprocessing_parser(),
+        ],
+    )
+
+    insert_supressions_parser.add_argument(
+        "--kind",
+        default="fixme",
+        choices=[kind.name.lower() for kind in SuppressionCommentKind],
+        help="Should we use `# lint-fixme` or `# lint-ignore`? Defaults to 'fixme'.",
+    )
+    message_group = insert_supressions_parser.add_mutually_exclusive_group()
+    message_group.add_argument(
+        "--message",
+        default=None,
+        help="Overrides the lint message used in the fixme comment.",
+    )
+    message_group.add_argument(
+        "--no-message",
+        action="store_true",
+        help=(
+            "Don't include a message with the suppression comment. Only include the "
+            + "lint code."
+        ),
+    )
+    insert_supressions_parser.add_argument(
+        "--max-lines",
+        default=3,
+        type=int,
+        help="The maximum number of lines a comment can span before getting truncated",
+    )
+
+    insert_supressions_parser.set_defaults(subparser_fn=_main)
+
+
+def _main(args: argparse.Namespace):
+    width = shutil.get_terminal_size(fallback=(80, 24)).columns
+
+    # Find files if directory was provided.
+    file_paths = tuple(find_files((str(p) for p in args.paths)))
+
+    if not args.compact:
+        print(f"Scanning {len(file_paths)} files")
+        print()
+    start_time = time.time()
+
+    if args.no_message:
+        message = MessageKind.NO_MESSAGE
+    elif args.message is not None:
+        message = args.message
+    else:
+        message = MessageKind.USE_LINT_REPORT
+
+    metadata_caches: Optional[Mapping[str, Mapping["ProviderT", object]]] = None
+    if rules_require_metadata_cache({args.rule}):
+        metadata_caches = get_metadata_caches(args.cache_timeout, file_paths)
+
+    # opts is a more type-safe version of args that we pass around
+    opts = InsertSuppressionsOpts(
+        rule=args.rule,
+        skip_autoformatter=args.skip_autoformatter,
+        kind=SuppressionCommentKind[args.kind.upper()],
+        message=message,
+        max_lines=args.max_lines,
+        formatter=SuppressedLintRuleReportFormatter(width, args.compact),
+    )
+
+    formatted_reports_iter = itertools.chain.from_iterable(
+        map_paths(
+            get_formatted_reports_for_path,
+            file_paths,
+            opts,
+            workers=args.workers,
+            metadata_caches=metadata_caches,
+        )
+    )
+
+    formatted_reports = []
+    for formatted_report in formatted_reports_iter:
+        # Reports are yielded as soon as they're available. Stream the output to the
+        # terminal.
+        print(formatted_report)
+        # save the report from the iterator for later use
+        formatted_reports.append(formatted_report)
+
+    if not args.compact:
+        print()
+        print(
+            f"Found {len(formatted_reports)} reports in {len(file_paths)} files in "
+            + f"{time.time() - start_time :.2f} seconds."
+        )
+    return 0
+
+
 if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -37,8 +37,8 @@ def main(argv: List[str] = sys.argv[1:]) -> None:
     run_rules.register_subparser(subparser)
 
     args = parser.parse_args(argv)
-    args.subparser_fn(args)
+    sys.exit(args.subparser_fn(args))
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -12,13 +12,12 @@
 
 import argparse
 import sys
-from typing import List
 
 from fixit._version import FIXIT_VERSION
 from fixit.cli import add_new_rule, apply_fix, insert_suppressions, run_rules
 
 
-def main(args: List[str] = sys.argv[1:]) -> None:
+def main(args=sys.argv[1:]) -> None:
     """Launch the CLI and its arguments."""
     parser = argparse.ArgumentParser(
         prog="fixit",

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -12,12 +12,12 @@
 
 import argparse
 import sys
-
+from typing import List
 from fixit._version import FIXIT_VERSION
 from fixit.cli import add_new_rule, apply_fix, insert_suppressions, run_rules
 
 
-def main(args=sys.argv[1:]) -> None:
+def main(argv: List[str] = sys.argv[1:]) -> None:
     """Launch the CLI and its arguments."""
     parser = argparse.ArgumentParser(
         prog="fixit",
@@ -35,7 +35,7 @@ def main(args=sys.argv[1:]) -> None:
     apply_fix.register_subparser(subparser)
     insert_suppressions.register_subparser(subparser)
 
-    args = parser.parse_args(args)
+    args = parser.parse_args(argv)
     args.subparser_fn(args)
 
 

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -32,7 +32,9 @@ def get_fixit_version() -> str:
     )
 
     version: ModuleType = importlib.util.module_from_spec(spec)
+    # pyre-ignore Pyre doesn't know about importlib entirely.
     spec.loader.exec_module(version)
+    # pyre-ignore Pyre has no way of knowing that this constant exists.
     return version.FIXIT_VERSION
 
 

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -19,7 +19,7 @@ from fixit.cli import add_new_rule, apply_fix, insert_suppressions, run_rules
 
 
 def main(argv: List[str] = sys.argv[1:]) -> None:
-    """Launch the CLI and its arguments."""
+    """Fixit CLI and its sub-commands"""
     parser = argparse.ArgumentParser(
         prog="fixit",
         description="These are common Fixit commands used in various situations:",
@@ -32,9 +32,9 @@ def main(argv: List[str] = sys.argv[1:]) -> None:
     subparser = parser.add_subparsers(title="command")
 
     add_new_rule.register_subparser(subparser)
-    run_rules.register_subparser(subparser)
     apply_fix.register_subparser(subparser)
     insert_suppressions.register_subparser(subparser)
+    run_rules.register_subparser(subparser)
 
     args = parser.parse_args(argv)
     args.subparser_fn(args)

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -13,6 +13,7 @@
 import argparse
 import sys
 from typing import List
+
 from fixit._version import FIXIT_VERSION
 from fixit.cli import add_new_rule, apply_fix, insert_suppressions, run_rules
 

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -1,0 +1,71 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage:
+#
+#   $ fixit run_rules --help
+#   $ fixit apply_fix --help
+#   $ fixit insert_suppressions --help
+#   $ fixit add_new_rule --help
+
+import argparse
+import importlib.util
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from types import ModuleType
+from typing import List
+
+from absl import app
+from absl.flags import argparse_flags
+
+from fixit.cli import add_new_rule, apply_fix, insert_suppressions, run_rules
+
+
+def get_fixit_version() -> str:
+    """Get current Fixit's version"""
+    directory = Path(__file__).resolve().parents[1]
+
+    spec: ModuleSpec = importlib.util.spec_from_file_location(
+        "version", directory / "_version.py"
+    )
+
+    version: ModuleType = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(version)
+    return version.FIXIT_VERSION
+
+
+def _parse_flags(argv: List[str]) -> argparse.Namespace:
+    """Command lines flag parsing."""
+    parser = argparse_flags.ArgumentParser(
+        prog="fixit",
+        description="These are common Fixit commands used in various situations:",
+    )
+
+    parser.add_argument("--version", action="version", version=get_fixit_version())
+    parser.set_defaults(subparser_fn=lambda _: parser.print_help())
+
+    # Register sub-commands
+    subparser = parser.add_subparsers(title="command")
+
+    add_new_rule.register_subparser(subparser)
+    run_rules.register_subparser(subparser)
+    apply_fix.register_subparser(subparser)
+    insert_suppressions.register_subparser(subparser)
+
+    return parser.parse_args(argv[1:])
+
+
+def main(args: argparse.Namespace) -> None:
+    # Launch the subcommand defined in the subparser (or default to print help)
+    args.subparser_fn(args)
+
+
+def launch_cli() -> None:
+    """Parse arguments and launch the CLI main function."""
+    app.run(main, flags_parser=_parse_flags)
+
+
+if __name__ == "__main__":
+    launch_cli()

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -41,4 +41,4 @@ def main(argv: List[str] = sys.argv[1:]) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/fixit/cli/main.py
+++ b/fixit/cli/main.py
@@ -11,41 +11,21 @@
 #   $ fixit add_new_rule --help
 
 import argparse
-import importlib.util
-from importlib.machinery import ModuleSpec
-from pathlib import Path
-from types import ModuleType
+import sys
 from typing import List
 
-from absl import app
-from absl.flags import argparse_flags
-
+from fixit._version import FIXIT_VERSION
 from fixit.cli import add_new_rule, apply_fix, insert_suppressions, run_rules
 
 
-def get_fixit_version() -> str:
-    """Get current Fixit's version"""
-    directory = Path(__file__).resolve().parents[1]
-
-    spec: ModuleSpec = importlib.util.spec_from_file_location(
-        "version", directory / "_version.py"
-    )
-
-    version: ModuleType = importlib.util.module_from_spec(spec)
-    # pyre-ignore Pyre doesn't know about importlib entirely.
-    spec.loader.exec_module(version)
-    # pyre-ignore Pyre has no way of knowing that this constant exists.
-    return version.FIXIT_VERSION
-
-
-def _parse_flags(argv: List[str]) -> argparse.Namespace:
-    """Command lines flag parsing."""
-    parser = argparse_flags.ArgumentParser(
+def main(args: List[str] = sys.argv[1:]) -> None:
+    """Launch the CLI and its arguments."""
+    parser = argparse.ArgumentParser(
         prog="fixit",
         description="These are common Fixit commands used in various situations:",
     )
 
-    parser.add_argument("--version", action="version", version=get_fixit_version())
+    parser.add_argument("--version", action="version", version=FIXIT_VERSION)
     parser.set_defaults(subparser_fn=lambda _: parser.print_help())
 
     # Register sub-commands
@@ -56,18 +36,9 @@ def _parse_flags(argv: List[str]) -> argparse.Namespace:
     apply_fix.register_subparser(subparser)
     insert_suppressions.register_subparser(subparser)
 
-    return parser.parse_args(argv[1:])
-
-
-def main(args: argparse.Namespace) -> None:
-    # Launch the subcommand defined in the subparser (or default to print help)
+    args = parser.parse_args(args)
     args.subparser_fn(args)
 
 
-def launch_cli() -> None:
-    """Parse arguments and launch the CLI main function."""
-    app.run(main, flags_parser=_parse_flags)
-
-
 if __name__ == "__main__":
-    launch_cli()
+    main()

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -199,7 +199,7 @@ def register_subparser(parsers: argparse._SubParsersAction) -> None:
     run_rules_parser.set_defaults(subparser_fn=_main)
 
 
-def _main(args: argparse.Namespace):
+def _main(args: argparse.Namespace) -> None:
     width = shutil.get_terminal_size(fallback=(80, 24)).columns
 
     # expand path if it's a directory
@@ -248,9 +248,6 @@ def _main(args: argparse.Namespace):
             f"Found {len(formatted_reports)} reports in {len(file_paths)} files in "
             + f"{time.time() - start_time :.2f} seconds."
         )
-
-    # Return with an exit code of 1 if there are any violations found.
-    return int(bool(formatted_reports))
 
 
 if __name__ == "__main__":

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -26,6 +26,7 @@ from libcst.metadata import MetadataWrapper
 from fixit.cli import find_files, map_paths
 from fixit.cli.args import (
     get_compact_parser,
+    get_metadata_cache_parser,
     get_multiprocessing_parser,
     get_paths_parser,
     get_rules_parser,
@@ -57,6 +58,7 @@ PARENTS: List[argparse.ArgumentParser] = [
     get_skip_ignore_byte_marker_parser(),
     get_compact_parser(),
     get_multiprocessing_parser(),
+    get_metadata_cache_parser()
 ]
 
 
@@ -102,12 +104,7 @@ def get_formatted_reports_for_path(
 
 def _add_arguments(parser: argparse.ArgumentParser) -> None:
     """All required arguments for `run_rules`"""
-    parser.add_argument(
-        "--cache-timeout",
-        type=int,
-        help="Timeout (seconds) for metadata cache fetching. Default is 2 seconds.",
-        default=2,
-    )
+    pass
 
 
 def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> None:

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -100,6 +100,7 @@ def get_formatted_reports_for_path(
     return [opts.formatter.format(rr) for rr in raw_reports]
 
 
+# pyre-ignore Pyre confused when the argument type is two
 def _parser_arguments(
     parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
     sub_parser: bool = True,

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -58,7 +58,7 @@ PARENTS: List[argparse.ArgumentParser] = [
     get_skip_ignore_byte_marker_parser(),
     get_compact_parser(),
     get_multiprocessing_parser(),
-    get_metadata_cache_parser()
+    get_metadata_cache_parser(),
 ]
 
 

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -100,12 +100,12 @@ def get_formatted_reports_for_path(
     return [opts.formatter.format(rr) for rr in raw_reports]
 
 
-# pyre-ignore Pyre confused when the argument type is two
 def _parser_arguments(
     parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
     sub_parser: bool = True,
 ) -> None:
     """All required arguments for `run_rules`"""
+    # pyre-ignore Pyre confused when the argument type is two
     parser.add_argument(
         "--cache-timeout",
         type=int,
@@ -114,8 +114,10 @@ def _parser_arguments(
     )
 
     if sub_parser:
+        # pyre-ignore Pyre confused when the argument type is two
         parser.set_defaults(subparser_fn=_main)
     else:
+        # pyre-ignore Pyre confused when the argument type is two
         _main(parser.parse_args())
 
 

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -100,9 +100,8 @@ def get_formatted_reports_for_path(
     return [opts.formatter.format(rr) for rr in raw_reports]
 
 
-def _parser_arguments(
-    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
-    sub_parser: bool = True,
+def _add_arguments(
+    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser]
 ) -> None:
     """All required arguments for `run_rules`"""
     # pyre-ignore Pyre confused when the argument type is two
@@ -113,13 +112,6 @@ def _parser_arguments(
         default=2,
     )
 
-    if sub_parser:
-        # pyre-ignore Pyre confused when the argument type is two
-        parser.set_defaults(subparser_fn=_main)
-    else:
-        # pyre-ignore Pyre confused when the argument type is two
-        _main(parser.parse_args())
-
 
 # pyre-ignore Pyre doesn't know about varible type when None given
 def register_subparser(parser: argparse._SubParsersAction = None) -> None:
@@ -129,7 +121,8 @@ def register_subparser(parser: argparse._SubParsersAction = None) -> None:
             description=DESCRIPTION,
             parents=PARENTS,
         )
-        _parser_arguments(run_rules_parser, sub_parser=False)
+        _add_arguments(run_rules_parser)
+        _main(run_rules_parser.parse_args())
 
     else:
         run_rules_parser = parser.add_parser(
@@ -138,7 +131,8 @@ def register_subparser(parser: argparse._SubParsersAction = None) -> None:
             parents=PARENTS,
             help="Run fixit rules against python code",
         )
-        _parser_arguments(run_rules_parser)
+        _add_arguments(run_rules_parser)
+        run_rules_parser.set_defaults(subparser_fn=_main)
 
 
 def _main(args: argparse.Namespace) -> None:

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -15,6 +15,7 @@
 import argparse
 import itertools
 import shutil
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -128,7 +129,7 @@ def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> N
         run_rules_parser.set_defaults(subparser_fn=_main)
 
 
-def _main(args: argparse.Namespace) -> None:
+def _main(args: argparse.Namespace) -> int:
     width = shutil.get_terminal_size(fallback=(80, 24)).columns
 
     # expand path if it's a directory
@@ -178,6 +179,9 @@ def _main(args: argparse.Namespace) -> None:
             + f"{time.time() - start_time :.2f} seconds."
         )
 
+    # Return with an exit code of 1 if there are any violations found.
+    return int(bool(formatted_reports))
+
 
 if __name__ == "__main__":
-    register_subparser()
+    sys.exit(register_subparser())

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -18,7 +18,7 @@ import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional
 
 from libcst import ParserSyntaxError, parse_module
 from libcst.metadata import MetadataWrapper
@@ -100,11 +100,8 @@ def get_formatted_reports_for_path(
     return [opts.formatter.format(rr) for rr in raw_reports]
 
 
-def _add_arguments(
-    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser]
-) -> None:
+def _add_arguments(parser: argparse.ArgumentParser) -> None:
     """All required arguments for `run_rules`"""
-    # pyre-ignore Pyre confused when the argument type is two
     parser.add_argument(
         "--cache-timeout",
         type=int,
@@ -113,8 +110,7 @@ def _add_arguments(
     )
 
 
-# pyre-ignore Pyre doesn't know about varible type when None given
-def register_subparser(parser: argparse._SubParsersAction = None) -> None:
+def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> None:
     """Add parser or subparser for `run_rules` command."""
     if parser is None:
         run_rules_parser = argparse.ArgumentParser(

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -15,11 +15,10 @@
 import argparse
 import itertools
 import shutil
-import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Union
 
 from libcst import ParserSyntaxError, parse_module
 from libcst.metadata import MetadataWrapper
@@ -45,6 +44,20 @@ from fixit.rule_lint_engine import lint_file
 
 if TYPE_CHECKING:
     from libcst.metadata.base_provider import ProviderT
+
+DESCRIPTION = """Validates your lint rules by running them against the specified,
+directory or file(s). This is not a substitute for unit tests, but it can provide
+additional confidence in your lint rules. If no lint rules or packages are specified,
+runs all lint rules found in the packages specified in `fixit.config.yaml`."""
+
+PARENTS = [
+    get_paths_parser(),
+    get_rules_parser(),
+    get_use_ignore_comments_parser(),
+    get_skip_ignore_byte_marker_parser(),
+    get_compact_parser(),
+    get_multiprocessing_parser(),
+]
 
 
 @dataclass(frozen=True)
@@ -87,25 +100,11 @@ def get_formatted_reports_for_path(
     return [opts.formatter.format(rr) for rr in raw_reports]
 
 
-def main(raw_args: Sequence[str]) -> int:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Validates your lint rules by running them against the specified, "
-            + "directory or file(s). This is not a substitute for unit tests, "
-            + "but it can provide additional confidence in your lint rules.\n"
-            + "If no lint rules or packages are specified, runs all lint rules "
-            + "found in the packages specified in `fixit.config.yaml`."
-        ),
-        parents=[
-            get_paths_parser(),
-            get_rules_parser(),
-            get_use_ignore_comments_parser(),
-            get_skip_ignore_byte_marker_parser(),
-            get_compact_parser(),
-            get_multiprocessing_parser(),
-        ],
-    )
-
+def _parser_arguments(
+    parser: Union[argparse._SubParsersAction, argparse.ArgumentParser],
+    sub_parser: bool = True,
+) -> None:
+    """All required arguments for `run_rules`"""
     parser.add_argument(
         "--cache-timeout",
         type=int,
@@ -113,90 +112,29 @@ def main(raw_args: Sequence[str]) -> int:
         default=2,
     )
 
-    args = parser.parse_args(raw_args)
-    width = shutil.get_terminal_size(fallback=(80, 24)).columns
+    if sub_parser:
+        parser.set_defaults(subparser_fn=_main)
+    else:
+        _main(parser.parse_args())
 
-    # expand path if it's a directory
-    file_paths = tuple(find_files(args.paths))
-    all_rules = args.rules
 
-    if not args.compact:
-        print(f"Scanning {len(file_paths)} files")
-        print(f"Testing {len(all_rules)} rules")
-        print()
-    start_time = time.time()
-
-    metadata_caches: Optional[Mapping[str, Mapping["ProviderT", object]]] = None
-    if rules_require_metadata_cache(all_rules):
-        metadata_caches = get_metadata_caches(args.cache_timeout, file_paths)
-
-    # opts is a more type-safe version of args that we pass around
-    opts = LintOpts(
-        rules=all_rules,
-        use_ignore_byte_markers=args.use_ignore_byte_markers,
-        use_ignore_comments=args.use_ignore_comments,
-        formatter=LintRuleReportFormatter(width, args.compact),
-    )
-
-    formatted_reports_iter = itertools.chain.from_iterable(
-        map_paths(
-            get_formatted_reports_for_path,
-            file_paths,
-            opts,
-            workers=args.workers,
-            metadata_caches=metadata_caches,
+def register_subparser(parser: argparse._SubParsersAction = None) -> None:
+    """Add parser or subparser for `run_rules` command."""
+    if parser is None:
+        run_rules_parser = argparse.ArgumentParser(
+            description=DESCRIPTION,
+            parents=PARENTS,
         )
-    )
+        _parser_arguments(run_rules_parser, sub_parser=False)
 
-    formatted_reports = []
-    for formatted_report in formatted_reports_iter:
-        # Reports are yielded as soon as they're available. Stream the output to the
-        # terminal.
-        print(formatted_report)
-        # save the report from the iterator for later use
-        formatted_reports.append(formatted_report)
-
-    if not args.compact:
-        print()
-        print(
-            f"Found {len(formatted_reports)} reports in {len(file_paths)} files in "
-            + f"{time.time() - start_time :.2f} seconds."
+    else:
+        run_rules_parser = parser.add_parser(
+            "run_rules",
+            description=DESCRIPTION,
+            parents=PARENTS,
+            help="Run fixit rules against python code",
         )
-
-    # Return with an exit code of 1 if there are any violations found.
-    return int(bool(formatted_reports))
-
-
-def register_subparser(parsers: argparse._SubParsersAction) -> None:
-    """Add subparser for `run_rules` command."""
-    run_rules_parser = parsers.add_parser(
-        "run_rules",
-        description=(
-            "Validates your lint rules by running them against the specified, "
-            + "directory or file(s). This is not a substitute for unit tests, "
-            + "but it can provide additional confidence in your lint rules.\n"
-            + "If no lint rules or packages are specified, runs all lint rules "
-            + "found in the packages specified in `fixit.config.yaml`."
-        ),
-        help="Run fixit rules against python code",
-        parents=[
-            get_paths_parser(),
-            get_rules_parser(),
-            get_use_ignore_comments_parser(),
-            get_skip_ignore_byte_marker_parser(),
-            get_compact_parser(),
-            get_multiprocessing_parser(),
-        ],
-    )
-
-    run_rules_parser.add_argument(
-        "--cache-timeout",
-        type=int,
-        help="Timeout (seconds) for metadata cache fetching. Default is 2 seconds.",
-        default=2,
-    )
-
-    run_rules_parser.set_defaults(subparser_fn=_main)
+        _parser_arguments(run_rules_parser)
 
 
 def _main(args: argparse.Namespace) -> None:
@@ -251,4 +189,4 @@ def _main(args: argparse.Namespace) -> None:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    register_subparser()

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -18,7 +18,7 @@ import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Union
 
 from libcst import ParserSyntaxError, parse_module
 from libcst.metadata import MetadataWrapper
@@ -45,12 +45,12 @@ from fixit.rule_lint_engine import lint_file
 if TYPE_CHECKING:
     from libcst.metadata.base_provider import ProviderT
 
-DESCRIPTION = """Validates your lint rules by running them against the specified,
+DESCRIPTION: str = """Validates your lint rules by running them against the specified,
 directory or file(s). This is not a substitute for unit tests, but it can provide
 additional confidence in your lint rules. If no lint rules or packages are specified,
 runs all lint rules found in the packages specified in `fixit.config.yaml`."""
 
-PARENTS = [
+PARENTS: List[argparse.ArgumentParser] = [
     get_paths_parser(),
     get_rules_parser(),
     get_use_ignore_comments_parser(),
@@ -118,6 +118,7 @@ def _parser_arguments(
         _main(parser.parse_args())
 
 
+# pyre-ignore Pyre doesn't know about varible type when None given
 def register_subparser(parser: argparse._SubParsersAction = None) -> None:
     """Add parser or subparser for `run_rules` command."""
     if parser is None:

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -116,7 +116,7 @@ def register_subparser(parser: Optional[argparse._SubParsersAction] = None) -> N
             parents=PARENTS,
         )
         _add_arguments(run_rules_parser)
-        _main(run_rules_parser.parse_args())
+        sys.exit(_main(run_rules_parser.parse_args()))
 
     else:
         run_rules_parser = parser.add_parser(
@@ -184,4 +184,4 @@ def _main(args: argparse.Namespace) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(register_subparser())
+    register_subparser()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-absl-py>=0.10.0
 black>=19.10b0
 codecov>=2.0.15
 coverage>=4.5.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+absl-py>=0.10.0
 black>=19.10b0
 codecov>=2.0.15
 coverage>=4.5.4

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,5 @@ setuptools.setup(
     ],
     zip_safe=False,  # for mypy compatibility https://mypy.readthedocs.io/en/latest/installed_packages.html
     include_package_data=True,
-    entry_points={"console_scripts": ["fixit = fixit.cli.main:launch_cli"]},
+    entry_points={"console_scripts": ["fixit = fixit.cli.main:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -57,4 +57,5 @@ setuptools.setup(
     ],
     zip_safe=False,  # for mypy compatibility https://mypy.readthedocs.io/en/latest/installed_packages.html
     include_package_data=True,
+    entry_points={"console_scripts": ["fixit = fixit.cli.main:launch_cli"]},
 )


### PR DESCRIPTION
## Summary
* Fixes #147 #124
* CLI for fixit 
* Supports both new CLI and existing scripts

Installation: 
```bash
$ pip install fixit
```
Usage: 
```bash
$ fixit --help
$ fixit run_rules --help
$ fixit apply_fix --help
$ fixit insert_suppressions --help
$ fixit add_new_rule --help
```

This PR creates new CLI for fixit module

Please follow this sequence to review this PR:
```
1. setup.py
2. main.py
3. {run_rules.py, apply_fix.py, insert_suppressions.py, add_new_rule.py}
```
*Note: To support backward compatibility, I have changed existing files `run_rules.py, apply_fix.py etc.` for this cli without affecting previous scripts workflow with a new architecture. Will remove redundant code once this CLI published and more robust.*