### PR TITLE
addressing issue 114: await async rule does not account for decorators

### DIFF
--- a/fixit/rules/await_async_call.py
+++ b/fixit/rules/await_async_call.py
@@ -319,8 +319,8 @@ class AwaitAsyncCallRule(CstLintRule):
 
     @staticmethod
     def _is_awaitable_callable(annotation: str) -> bool:
-        if not (annotation.startswith("typing.Callable") 
-            or annotation.startswith("typing.ClassMethod") or annotation.startswith("StaticMethod")):
+        if not (annotation.startswith("typing.Callable")
+                or annotation.startswith("typing.ClassMethod") or annotation.startswith("StaticMethod")):
             # Exit early if this is not even a `typing.Callable` annotation.
             return False
         try:

--- a/fixit/rules/await_async_call.py
+++ b/fixit/rules/await_async_call.py
@@ -321,7 +321,7 @@ class AwaitAsyncCallRule(CstLintRule):
     def _is_awaitable_callable(annotation: str) -> bool:
         if not (
             annotation.startswith("typing.Callable")
-            or annotation.startswith("typing.ClassMethod") 
+            or annotation.startswith("typing.ClassMethod")
             or annotation.startswith("StaticMethod")
         ):
             # Exit early if this is not even a `typing.Callable` annotation.

--- a/fixit/rules/await_async_call.py
+++ b/fixit/rules/await_async_call.py
@@ -298,7 +298,8 @@ class AwaitAsyncCallRule(CstLintRule):
             """,
             expected_replacement="""
             class Foo:
-                async def _method(self): pass
+                @classmethod
+                async def _method(cls): pass
             await Foo._method()
             """,
         ),
@@ -311,6 +312,7 @@ class AwaitAsyncCallRule(CstLintRule):
             """,
             expected_replacement="""
             class Foo:
+                @staticmethod
                 async def _method(self): pass
             await Foo._method()
             """,

--- a/fixit/rules/await_async_call.py
+++ b/fixit/rules/await_async_call.py
@@ -289,11 +289,38 @@ class AwaitAsyncCallRule(CstLintRule):
             while not await bar(): pass
             """,
         ),
+        Invalid(
+            """
+            class Foo:
+                @classmethod
+                async def _method(cls): pass
+            Foo._method()
+            """,
+            expected_replacement="""
+            class Foo:
+                async def _method(self): pass
+            await Foo._method()
+            """,
+        ),
+        Invalid(
+            """
+            class Foo:
+                @staticmethod
+                async def _method(self): pass
+            Foo._method()
+            """,
+            expected_replacement="""
+            class Foo:
+                async def _method(self): pass
+            await Foo._method()
+            """,
+        ),
     ]
 
     @staticmethod
     def _is_awaitable_callable(annotation: str) -> bool:
-        if not annotation.startswith("typing.Callable"):
+        if not (annotation.startswith("typing.Callable") 
+            or annotation.startswith("typing.ClassMethod") or annotation.startswith("StaticMethod")):
             # Exit early if this is not even a `typing.Callable` annotation.
             return False
         try:

--- a/fixit/rules/await_async_call.py
+++ b/fixit/rules/await_async_call.py
@@ -319,8 +319,11 @@ class AwaitAsyncCallRule(CstLintRule):
 
     @staticmethod
     def _is_awaitable_callable(annotation: str) -> bool:
-        if not (annotation.startswith("typing.Callable")
-                or annotation.startswith("typing.ClassMethod") or annotation.startswith("StaticMethod")):
+        if not (
+            annotation.startswith("typing.Callable")
+            or annotation.startswith("typing.ClassMethod") 
+            or annotation.startswith("StaticMethod")
+        ):
             # Exit early if this is not even a `typing.Callable` annotation.
             return False
         try:

--- a/fixit/tests/fixtures/await_async_call/AwaitAsyncCallRule_INVALID_16.json
+++ b/fixit/tests/fixtures/await_async_call/AwaitAsyncCallRule_INVALID_16.json
@@ -1,0 +1,95 @@
+{
+  "types": [
+    {
+      "location": {
+        "start": {
+          "line": 1,
+          "column": 6
+        },
+        "stop": {
+          "line": 1,
+          "column": 9
+        }
+      },
+      "annotation": "typing.Type[fixit.tests.fixtures.await_async_call.tmp88jl7yhf.Foo]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 2,
+          "column": 5
+        },
+        "stop": {
+          "line": 2,
+          "column": 16
+        }
+      },
+      "annotation": "typing.Type[classmethod]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 3,
+          "column": 14
+        },
+        "stop": {
+          "line": 3,
+          "column": 21
+        }
+      },
+      "annotation": "typing.Callable(fixit.tests.fixtures.await_async_call.tmp88jl7yhf.Foo._method)[[], typing.Coroutine[typing.Any, typing.Any, unknown]]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 3,
+          "column": 22
+        },
+        "stop": {
+          "line": 3,
+          "column": 25
+        }
+      },
+      "annotation": "typing.Type[fixit.tests.fixtures.await_async_call.tmp88jl7yhf.Foo]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "stop": {
+          "line": 4,
+          "column": 3
+        }
+      },
+      "annotation": "typing.Type[fixit.tests.fixtures.await_async_call.tmp88jl7yhf.Foo]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "stop": {
+          "line": 4,
+          "column": 11
+        }
+      },
+      "annotation": "typing.Callable(fixit.tests.fixtures.await_async_call.tmp88jl7yhf.Foo._method)[[], typing.Coroutine[typing.Any, typing.Any, unknown]]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "stop": {
+          "line": 4,
+          "column": 13
+        }
+      },
+      "annotation": "typing.Coroutine[typing.Any, typing.Any, unknown]"
+    }
+  ]
+}

--- a/fixit/tests/fixtures/await_async_call/AwaitAsyncCallRule_INVALID_17.json
+++ b/fixit/tests/fixtures/await_async_call/AwaitAsyncCallRule_INVALID_17.json
@@ -1,0 +1,95 @@
+{
+  "types": [
+    {
+      "location": {
+        "start": {
+          "line": 1,
+          "column": 6
+        },
+        "stop": {
+          "line": 1,
+          "column": 9
+        }
+      },
+      "annotation": "typing.Type[fixit.tests.fixtures.await_async_call.tmpe9g2w713.Foo]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 2,
+          "column": 5
+        },
+        "stop": {
+          "line": 2,
+          "column": 17
+        }
+      },
+      "annotation": "typing.Type[staticmethod]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 3,
+          "column": 14
+        },
+        "stop": {
+          "line": 3,
+          "column": 21
+        }
+      },
+      "annotation": "typing.Callable(fixit.tests.fixtures.await_async_call.tmpe9g2w713.Foo._method)[[Named(self, unknown)], typing.Coroutine[typing.Any, typing.Any, unknown]]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 3,
+          "column": 22
+        },
+        "stop": {
+          "line": 3,
+          "column": 26
+        }
+      },
+      "annotation": "typing.Any"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "stop": {
+          "line": 4,
+          "column": 3
+        }
+      },
+      "annotation": "typing.Type[fixit.tests.fixtures.await_async_call.tmpe9g2w713.Foo]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "stop": {
+          "line": 4,
+          "column": 11
+        }
+      },
+      "annotation": "typing.Callable(fixit.tests.fixtures.await_async_call.tmpe9g2w713.Foo._method)[[Named(self, unknown)], typing.Coroutine[typing.Any, typing.Any, unknown]]"
+    },
+    {
+      "location": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "stop": {
+          "line": 4,
+          "column": 13
+        }
+      },
+      "annotation": "typing.Coroutine[typing.Any, typing.Any, unknown]"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
addressing issue 114: await async rule does not account for decorators
## Test Plan
tox -e py38 -- fixit.tests.AwaitAsyncCallRule
