### PR TITLE
Allow glob patterns instead of parent dirs for matching configs

### DIFF
--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -115,6 +115,13 @@ class LintRuleTestCase(unittest.TestCase):
                 raise AssertionError(
                     f"Expected:\n    {test_case.expected_str}\nBut found:\n    {report}"
                 )
+            if (
+                test_case.expected_message is not None
+                and test_case.expected_message != report.message
+            ):
+                raise AssertionError(
+                    f"Expected message:\n    {test_case.expected_message}\nBut got:\n    {report.message}"
+                )
 
             validate_patch(report, test_case)
 

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -78,6 +78,7 @@ class InvalidTestCase:
     expected_replacement: Optional[str] = None
     filename: str = DEFAULT_FILENAME
     config: LintConfig = DEFAULT_CONFIG
+    expected_message: Optional[str] = None
 
     @property
     def expected_str(self) -> str:

--- a/fixit/tests/test_import_constraints.py
+++ b/fixit/tests/test_import_constraints.py
@@ -36,7 +36,7 @@ class ImportConstraintsRuleConfigTest(UnitTest):
             _ImportConfig.from_config({"rules": [["*", "deny"], ["*", "allow"]]})
 
     def test_allow_or_deny(self) -> None:
-        with self.assertRaisesRegex(ValueError, "allow or deny"):
+        with self.assertRaisesRegex(ValueError, "not a valid RuleAction"):
             _ImportConfig.from_config(
                 {"rules": [["module_name", "wut"], ["*", "deny"]]}
             )


### PR DESCRIPTION
## Summary

Allow using globs as configuration for rules, not only parent directories.

This allows for creating specific rules for specific files, not only directories. For example:

```
{
    "*/urls.py": {
        "rules": [
            ["*", "deny"]
        ]
    }
}
```

Will allow specifying rules for all `urls` modules anywhere.

---

This also allows specifying if the allow or deny rule are meant for global or local scopes only:

```
{
    "*/urls.py": {
        "rules": [
            ["common.*", "allow"],
            ["*", "deny global"]
        ],
        "message": "Module in {current_file} only allows certain global imports. {imported} cannot be imported here."
    }
}
```

Allowing to import `common.*` anywhere and everything else only inside functions, as inner imports.

## Test Plan

Run tests