### PR TITLE
Add UseAssertIn lint rule to Fixit

### DIFF
--- a/fixit/rules/use_assert_in.py
+++ b/fixit/rules/use_assert_in.py
@@ -7,8 +7,7 @@ import libcst as cst
 import libcst.matchers as m
 from libcst.helpers import ensure_type
 
-from fixit.common.base import CstLintRule
-from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid
 
 
 class UseAssertInRule(CstLintRule):

--- a/fixit/rules/use_assert_in.py
+++ b/fixit/rules/use_assert_in.py
@@ -1,0 +1,172 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.helpers import ensure_type
+
+from fixit.common.base import CstLintRule
+from fixit.common.utils import InvalidTestCase as Invalid, ValidTestCase as Valid
+
+
+class UseAssertInRule(CstLintRule):
+    """
+    Discourages use of ``assertTrue(x in y)`` and ``assertFalse(x in y)``
+    as it is deprecated (https://docs.python.org/3.8/library/unittest.html#deprecated-aliases).
+    Use ``assertIn(x, y)`` and ``assertNotIn(x, y)``) instead.
+    """
+
+    MESSAGE: str = (
+        "Use assertIn/assertNotIn instead of assertTrue/assertFalse for inclusion check.\n"
+        + "See https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertIn)"
+    )
+
+    VALID = [
+        Valid("self.assertIn(a, b)"),
+        Valid("self.assertIn(f(), b)"),
+        Valid("self.assertIn(f(x), b)"),
+        Valid("self.assertIn(f(g(x)), b)"),
+        Valid("self.assertNotIn(a, b)"),
+        Valid("self.assertNotIn(f(), b)"),
+        Valid("self.assertNotIn(f(x), b)"),
+        Valid("self.assertNotIn(f(g(x)), b)"),
+    ]
+
+    INVALID = [
+        Invalid(
+            "self.assertTrue(a in b)",
+            expected_replacement="self.assertIn(a, b)",
+        ),
+        Invalid(
+            "self.assertTrue(f() in b)",
+            expected_replacement="self.assertIn(f(), b)",
+        ),
+        Invalid(
+            "self.assertTrue(f(x) in b)",
+            expected_replacement="self.assertIn(f(x), b)",
+        ),
+        Invalid(
+            "self.assertTrue(f(g(x)) in b)",
+            expected_replacement="self.assertIn(f(g(x)), b)",
+        ),
+        Invalid(
+            "self.assertTrue(a not in b)",
+            expected_replacement="self.assertNotIn(a, b)",
+        ),
+        Invalid(
+            "self.assertTrue(not a in b)",
+            expected_replacement="self.assertNotIn(a, b)",
+        ),
+        Invalid(
+            "self.assertFalse(a in b)",
+            expected_replacement="self.assertNotIn(a, b)",
+        ),
+    ]
+
+    def visit_Call(self, node: cst.Call) -> None:
+        # Todo: Make use of single extract instead of having several
+        # if else statemenets to make the code more robust and readable.
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(value=m.Name("self"), attr=m.Name("assertTrue")),
+                args=[
+                    m.Arg(
+                        m.Comparison(comparisons=[m.ComparisonTarget(operator=m.In())])
+                    )
+                ],
+            ),
+        ):
+            # self.assertTrue(a in b) -> self.assertIn(a, b)
+            new_call = node.with_changes(
+                func=cst.Attribute(value=cst.Name("self"), attr=cst.Name("assertIn")),
+                args=[
+                    cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left),
+                    cst.Arg(
+                        ensure_type(node.args[0].value, cst.Comparison)
+                        .comparisons[0]
+                        .comparator
+                    ),
+                ],
+            )
+            self.report(node, replacement=new_call)
+        else:
+            # ... -> self.assertNotIn(a, b)
+            matched, arg1, arg2 = False, None, None
+            if m.matches(
+                node,
+                m.Call(
+                    func=m.Attribute(value=m.Name("self"), attr=m.Name("assertTrue")),
+                    args=[
+                        m.Arg(
+                            m.UnaryOperation(
+                                operator=m.Not(),
+                                expression=m.Comparison(
+                                    comparisons=[m.ComparisonTarget(operator=m.In())]
+                                ),
+                            )
+                        )
+                    ],
+                ),
+            ):
+                # self.assertTrue(not a in b) -> self.assertNotIn(a, b)
+                matched = True
+                arg1 = cst.Arg(
+                    ensure_type(
+                        ensure_type(node.args[0].value, cst.UnaryOperation).expression,
+                        cst.Comparison,
+                    ).left
+                )
+                arg2 = cst.Arg(
+                    ensure_type(
+                        ensure_type(node.args[0].value, cst.UnaryOperation).expression,
+                        cst.Comparison,
+                    )
+                    .comparisons[0]
+                    .comparator
+                )
+            elif m.matches(
+                node,
+                m.Call(
+                    func=m.Attribute(value=m.Name("self"), attr=m.Name("assertTrue")),
+                    args=[
+                        m.Arg(m.Comparison(comparisons=[m.ComparisonTarget(m.NotIn())]))
+                    ],
+                ),
+            ):
+                # self.assertTrue(a not in b) -> self.assertNotIn(a, b)
+                matched = True
+                arg1 = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
+                arg2 = cst.Arg(
+                    ensure_type(node.args[0].value, cst.Comparison)
+                    .comparisons[0]
+                    .comparator
+                )
+            elif m.matches(
+                node,
+                m.Call(
+                    func=m.Attribute(value=m.Name("self"), attr=m.Name("assertFalse")),
+                    args=[
+                        m.Arg(m.Comparison(comparisons=[m.ComparisonTarget(m.In())]))
+                    ],
+                ),
+            ):
+                # self.assertFalse(a in b) -> self.assertNotIn(a, b)
+                matched = True
+                arg1 = cst.Arg(ensure_type(node.args[0].value, cst.Comparison).left)
+                arg2 = cst.Arg(
+                    ensure_type(node.args[0].value, cst.Comparison)
+                    .comparisons[0]
+                    .comparator
+                )
+
+            if matched:
+                new_call = node.with_changes(
+                    func=cst.Attribute(
+                        value=cst.Name("self"), attr=cst.Name("assertNotIn")
+                    ),
+                    args=[arg1, arg2],
+                )
+                self.report(node, replacement=new_call)


### PR DESCRIPTION
## Summary
* Adding the Python lint rule for `assertIn/assertNotIn`.
* The reason we want to do this is to warn users to not make use of `assertTrue(x in y)/assertFalse(x in y)` which is deprecated in Py3.8. See [deprecated rules](https://docs.python.org/3.8/library/unittest.html#deprecated-aliases)

## Test Plan

Ran `tox -e py38 -- fixit.tests.UseAssertInRule`
```
GLOB sdist-make: /Users/dkteo/Fixit/setup.py
py37 inst-nodeps: /Users/dkteo/Fixit/.tox/.tmp/package/1/fixit-0.1.2.zip
py37 installed: alabaster==0.7.12,appdirs==1.4.4,appnope==0.1.0,argon2-cffi==20.1.0,async-generator==1.10,attrs==20.3.0,Babel==2.9.0,backcall==0.2.0,black==20.8b1,bleach==3.2.1,certifi==2020.11.8,cffi==1.14.4,chardet==3.0.4,click==7.1.2,codecov==2.1.10,coverage==5.3,decorator==4.4.2,defusedxml==0.6.0,diff-cover==4.0.1,distlib==0.3.1,docutils==0.16,entrypoints==0.3,filelock==3.0.12,fixit @ file:///Users/dkteo/Fixit/.tox/.tmp/package/1/fixit-0.1.2.zip,flake8==3.8.4,idna==2.10,imagesize==1.2.0,importlib-metadata==3.1.0,inflect==5.0.2,ipykernel==5.3.4,ipython==7.19.0,ipython-genutils==0.2.0,ipywidgets==7.5.1,isort==5.6.4,jedi==0.17.2,Jinja2==2.11.2,jinja2-pluralize==0.3.0,jsonschema==3.2.0,jupyter==1.0.0,jupyter-client==6.1.7,jupyter-console==6.2.0,jupyter-core==4.7.0,jupyterlab-pygments==0.1.2,libcst==0.3.14,MarkupSafe==1.1.1,mccabe==0.6.1,mistune==0.8.4,mypy-extensions==0.4.3,nbclient==0.5.1,nbconvert==6.0.7,nbformat==5.0.8,nbsphinx==0.8.0,nest-asyncio==1.4.3,notebook==6.1.5,packaging==20.7,pandocfilters==1.4.3,parso==0.7.1,pathspec==0.8.1,pexpect==4.8.0,pickleshare==0.7.5,pluggy==0.13.1,prometheus-client==0.9.0,prompt-toolkit==3.0.8,psutil==5.7.3,ptyprocess==0.6.0,py==1.9.0,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,Pygments==2.7.2,pyparsing==2.4.7,pyre-check==0.0.41,pyre-extensions==0.0.19,pyrsistent==0.17.3,python-dateutil==2.8.1,pytz==2020.4,pywatchman==1.4.1,PyYAML==5.3.1,pyzmq==20.0.0,qtconsole==5.0.1,QtPy==1.9.0,regex==2020.11.13,requests==2.25.0,Send2Trash==1.5.0,six==1.15.0,snowballstemmer==2.0.0,Sphinx @ git+https://github.com/jimmylai/sphinx.git@971540b26a8412399a9face3752cafc4519ff748,sphinx-rtd-theme==0.5.0,sphinxcontrib-applehelp==1.0.2,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==1.0.3,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.4,terminado==0.9.1,testpath==0.4.4,toml==0.10.2,tornado==6.1,tox==3.20.1,traitlets==5.0.5,typed-ast==1.4.1,typing-extensions==3.7.4.3,typing-inspect==0.6.0,urllib3==1.26.2,virtualenv==20.2.1,wcwidth==0.2.5,webencodings==0.5.1,widgetsnbextension==3.5.1,zipp==3.4.0
py37 run-test-pre: PYTHONHASHSEED='2358965140'
py37 run-test: commands[0] | python -m unittest fixit.tests.UseAssertInRule
...............
----------------------------------------------------------------------
Ran 15 tests in 0.135s

OK
______________________________________________________________________________________ summary ______________________________________________________________________________________
  py37: commands succeeded
  congratulations :)
```

Ran `tox -e autofix`
```
GLOB sdist-make: /Users/dkteo/Fixit/setup.py
autofix inst-nodeps: /Users/dkteo/Fixit/.tox/.tmp/package/1/fixit-0.1.2.zip
autofix installed: alabaster==0.7.12,appdirs==1.4.4,appnope==0.1.0,argon2-cffi==20.1.0,async-generator==1.10,attrs==20.3.0,Babel==2.9.0,backcall==0.2.0,black==20.8b1,bleach==3.2.1,certifi==2020.11.8,cffi==1.14.4,chardet==3.0.4,click==7.1.2,codecov==2.1.10,coverage==5.3,decorator==4.4.2,defusedxml==0.6.0,diff-cover==4.0.1,distlib==0.3.1,docutils==0.16,entrypoints==0.3,filelock==3.0.12,fixit @ file:///Users/dkteo/Fixit/.tox/.tmp/package/1/fixit-0.1.2.zip,flake8==3.8.4,idna==2.10,imagesize==1.2.0,importlib-metadata==3.1.0,inflect==5.0.2,ipykernel==5.3.4,ipython==7.19.0,ipython-genutils==0.2.0,ipywidgets==7.5.1,isort==5.6.4,jedi==0.17.2,Jinja2==2.11.2,jinja2-pluralize==0.3.0,jsonschema==3.2.0,jupyter==1.0.0,jupyter-client==6.1.7,jupyter-console==6.2.0,jupyter-core==4.7.0,jupyterlab-pygments==0.1.2,libcst==0.3.14,MarkupSafe==1.1.1,mccabe==0.6.1,mistune==0.8.4,mypy-extensions==0.4.3,nbclient==0.5.1,nbconvert==6.0.7,nbformat==5.0.8,nbsphinx==0.8.0,nest-asyncio==1.4.3,notebook==6.1.5,packaging==20.7,pandocfilters==1.4.3,parso==0.7.1,pathspec==0.8.1,pexpect==4.8.0,pickleshare==0.7.5,pluggy==0.13.1,prometheus-client==0.9.0,prompt-toolkit==3.0.8,psutil==5.7.3,ptyprocess==0.6.0,py==1.9.0,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,Pygments==2.7.2,pyparsing==2.4.7,pyre-check==0.0.41,pyre-extensions==0.0.19,pyrsistent==0.17.3,python-dateutil==2.8.1,pytz==2020.4,pywatchman==1.4.1,PyYAML==5.3.1,pyzmq==20.0.0,qtconsole==5.0.1,QtPy==1.9.0,regex==2020.11.13,requests==2.25.0,Send2Trash==1.5.0,six==1.15.0,snowballstemmer==2.0.0,Sphinx @ git+https://github.com/jimmylai/sphinx.git@971540b26a8412399a9face3752cafc4519ff748,sphinx-rtd-theme==0.5.0,sphinxcontrib-applehelp==1.0.2,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==1.0.3,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.4,terminado==0.9.1,testpath==0.4.4,toml==0.10.2,tornado==6.1,tox==3.20.1,traitlets==5.0.5,typed-ast==1.4.1,typing-extensions==3.7.4.3,typing-inspect==0.6.0,urllib3==1.26.2,virtualenv==20.2.1,wcwidth==0.2.5,webencodings==0.5.1,widgetsnbextension==3.5.1,zipp==3.4.0
autofix run-test-pre: PYTHONHASHSEED='4017664482'
autofix run-test: commands[0] | isort -q .
autofix run-test: commands[1] | black .
All done! ✨ 🍰 ✨
95 files left unchanged.
______________________________________________________________________________________ summary ______________________________________________________________________________________
  autofix: commands succeeded
  congratulations :)
```