### PR TITLE
Fix broken testcase (cls_in_classmethod.py)

### DIFF
--- a/fixit/rules/cls_in_classmethod.py
+++ b/fixit/rules/cls_in_classmethod.py
@@ -159,7 +159,7 @@ class UseClsInClassmethodRule(CstLintRule):
                         return cls.__name__
 
                     # Same-named vars in sub-scopes should not be replaced.
-                    b = [a for a in [1,2,3]]
+                    b = [cls for a in [1,2,3]]
                     def f(a):
                         return a + 1
             """,


### PR DESCRIPTION
## Summary
* There was a typo in one of the expectations for one of the tests in `fixit/rules/cls_in_classmethod.py`.

* In this PR, we fix that typo to get CI to pass.

* This test failure can be seen in: https://github.com/Instagram/Fixit/pull/159/checks?check_run_id=1477345619, which was blocking the PR.

## Test Plan
```
tox -e py38 -- fixit.tests.UseClsInClassmethodRule
GLOB sdist-make: /Users/dkteo/Fixit/setup.py
py38 inst-nodeps: /Users/dkteo/Fixit/.tox/.tmp/package/1/fixit-0.1.2.zip
py38 installed: alabaster==0.7.12,appdirs==1.4.4,appnope==0.1.0,argon2-cffi==20.1.0,async-generator==1.10,attrs==20.3.0,Babel==2.9.0,backcall==0.2.0,black==20.8b1,bleach==3.2.1,certifi==2020.11.8,cffi==1.14.4,chardet==3.0.4,click==7.1.2,codecov==2.1.10,coverage==5.3,decorator==4.4.2,defusedxml==0.6.0,diff-cover==4.0.1,distlib==0.3.1,docutils==0.16,entrypoints==0.3,filelock==3.0.12,fixit @ file:///Users/dkteo/Fixit/.tox/.tmp/package/1/fixit-0.1.2.zip,flake8==3.8.4,idna==2.10,imagesize==1.2.0,inflect==5.0.2,ipykernel==5.3.4,ipython==7.19.0,ipython-genutils==0.2.0,ipywidgets==7.5.1,isort==5.6.4,jedi==0.17.2,Jinja2==2.11.2,jinja2-pluralize==0.3.0,jsonschema==3.2.0,jupyter==1.0.0,jupyter-client==6.1.7,jupyter-console==6.2.0,jupyter-core==4.7.0,jupyterlab-pygments==0.1.2,libcst==0.3.14,MarkupSafe==1.1.1,mccabe==0.6.1,mistune==0.8.4,mypy-extensions==0.4.3,nbclient==0.5.1,nbconvert==6.0.7,nbformat==5.0.8,nbsphinx==0.8.0,nest-asyncio==1.4.3,notebook==6.1.5,packaging==20.7,pandocfilters==1.4.3,parso==0.7.1,pathspec==0.8.1,pexpect==4.8.0,pickleshare==0.7.5,pluggy==0.13.1,prometheus-client==0.9.0,prompt-toolkit==3.0.8,psutil==5.7.3,ptyprocess==0.6.0,py==1.9.0,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,Pygments==2.7.2,pyparsing==2.4.7,pyre-check==0.0.41,pyre-extensions==0.0.19,pyrsistent==0.17.3,python-dateutil==2.8.1,pytz==2020.4,pywatchman==1.4.1,PyYAML==5.3.1,pyzmq==20.0.0,qtconsole==5.0.1,QtPy==1.9.0,regex==2020.11.13,requests==2.25.0,Send2Trash==1.5.0,six==1.15.0,snowballstemmer==2.0.0,Sphinx @ git+https://github.com/jimmylai/sphinx.git@971540b26a8412399a9face3752cafc4519ff748,sphinx-rtd-theme==0.5.0,sphinxcontrib-applehelp==1.0.2,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==1.0.3,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.4,terminado==0.9.1,testpath==0.4.4,toml==0.10.2,tornado==6.1,tox==3.20.1,traitlets==5.0.5,typed-ast==1.4.1,typing-extensions==3.7.4.3,typing-inspect==0.6.0,urllib3==1.26.2,virtualenv==20.2.1,wcwidth==0.2.5,webencodings==0.5.1,widgetsnbextension==3.5.1
py38 run-test-pre: PYTHONHASHSEED='1405088374'
py38 run-test: commands[0] | python -m unittest fixit.tests.UseClsInClassmethodRule
..........
----------------------------------------------------------------------
Ran 10 tests in 0.248s

OK
______________________________________________________________________________________ summary ______________________________________________________________________________________
  py38: commands succeeded
  congratulations :)
```

