### PR TITLE
Draft for IG Lint FYI workplace discussion

### DIFF
--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -27,7 +27,6 @@ from fixit.common.report import BaseLintRuleReport
 from fixit.common.utils import (
     InvalidTestCase,
     LintRuleCollectionT,
-    Position,
     ValidTestCase,
     _dedent,
     gen_type_inference_wrapper,

--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    List,
     Mapping,
     Optional,
     Sequence,

--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -6,7 +6,18 @@
 import unittest
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Type, Union, cast, List
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+    cast,
+)
 
 from libcst.metadata import MetadataWrapper
 
@@ -15,21 +26,24 @@ from fixit.common.generate_pyre_fixtures import get_fixture_path
 from fixit.common.report import BaseLintRuleReport
 from fixit.common.utils import (
     InvalidTestCase,
-    Position,
     LintRuleCollectionT,
+    Position,
     ValidTestCase,
     _dedent,
     gen_type_inference_wrapper,
 )
 from fixit.rule_lint_engine import lint_file
 
-def validate_patch(reports: List[BaseLintRuleReport], test_case: InvalidTestCase) -> None:
+
+def validate_patch(
+    reports: List[BaseLintRuleReport], test_case: InvalidTestCase
+) -> None:
     expected_replacement = test_case.expected_replacement
     patched_code = test_case.code
 
     for report in reports:
         patch = report.patch
-        if patch is None :
+        if patch is None:
             if expected_replacement is not None:
                 raise AssertionError(
                     "The rule for this test case has no auto-fix, but expected source was specified."
@@ -49,6 +63,7 @@ def validate_patch(reports: List[BaseLintRuleReport], test_case: InvalidTestCase
             + f"Expected:\n{expected_replacement}\n"
             + f"But found:\n{patched_code}"
         )
+
 
 @dataclass(frozen=True)
 class TestCasePrecursor:
@@ -96,12 +111,12 @@ class LintRuleTestCase(unittest.TestCase):
                 len(reports),
                 len(test_case.positions),
                 f'Expected report count to match positions count for this "invalid" test case, Reports : {len(reports)}, Positions: {len(test_case.positions)}.\n'
-                + "\n".join(str(e) for e in reports)
+                + "\n".join(str(e) for e in reports),
             )
 
             # pyre-fixme[16]: `Collection` has no attribute `__getitem__`.
 
-            #We assert above that reports and positions are the same length
+            # We assert above that reports and positions are the same length
             for report, position in zip(reports, test_case.positions):
                 if not (position.line is None or position.line == report.line):
                     raise AssertionError(

--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     Mapping,
     Optional,
@@ -16,7 +17,6 @@ from typing import (
     Type,
     Union,
     cast,
-    Collection,
 )
 
 from libcst.metadata import MetadataWrapper
@@ -33,9 +33,11 @@ from fixit.common.utils import (
 )
 from fixit.rule_lint_engine import lint_file
 
+
 def sort_reports(report: BaseLintRuleReport) -> float:
-    #Turn line, column into a 'line.column' float for sorting
-    return report.line + (report.column / pow(10,len(str(report.column))))
+    # Turn line, column into a 'line.column' float for sorting
+    return report.line + (report.column / pow(10, len(str(report.column))))
+
 
 def validate_patch(
     reports: Collection[BaseLintRuleReport], test_case: InvalidTestCase
@@ -124,18 +126,22 @@ class LintRuleTestCase(unittest.TestCase):
                     f'Expected report count to match positions count for this "invalid" test case, Reports : {len(reports)}, Positions: {len(positions)}.\n'
                     + "\n".join(str(e) for e in reports),
                 )
-                            # We assert above that reports and positions are the same length
+                # We assert above that reports and positions are the same length
                 for report, position in zip(reports, positions):
                     if not (position.line is None or position.line == report.line):
                         raise AssertionError(
                             f"Expected line: {position.line} but found line: {report.line}"
                         )
 
-                    if not (position.column is None or position.column == report.column):
+                    if not (
+                        position.column is None or position.column == report.column
+                    ):
                         raise AssertionError(
                             f"Expected column: {position.column} but found column: {report.column}"
                         )
-                    kind = test_case.kind if test_case.kind is not None else rule.__name__
+                    kind = (
+                        test_case.kind if test_case.kind is not None else rule.__name__
+                    )
                     if kind != report.code:
                         raise AssertionError(
                             f"Expected:\n    {test_case.expected_str}\nBut found:\n    {report}"
@@ -156,8 +162,6 @@ class LintRuleTestCase(unittest.TestCase):
                     f'Expected report count to match positions count for this "invalid" test case, Reports : {len(reports)}, Positions: 0.\n'
                     + "\n".join(str(e) for e in reports),
                 )
-
-
 
 
 def _gen_test_methods_for_rule(

--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -41,6 +41,9 @@ def validate_patch(
     expected_replacement = test_case.expected_replacement
     patched_code = test_case.code
 
+    # Patches will contain positional changes indexed from the beginning of the test code, so if
+    # there are multiple reports apply them from last to first so positions don't skew
+    reports.reverse()
     for report in reports:
         patch = report.patch
         if patch is None:
@@ -113,8 +116,6 @@ class LintRuleTestCase(unittest.TestCase):
                 f'Expected report count to match positions count for this "invalid" test case, Reports : {len(reports)}, Positions: {len(test_case.positions)}.\n'
                 + "\n".join(str(e) for e in reports),
             )
-
-            # pyre-fixme[16]: `Collection` has no attribute `__getitem__`.
 
             # We assert above that reports and positions are the same length
             for report, position in zip(reports, test_case.positions):

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -96,13 +96,16 @@ class InvalidTestCase:
     expected_message: Optional[str] = None
 
     @property
-    def expected_str(self) -> List[str]:
-        return [
-            f"{_str_or_any(p.line)}:{_str_or_any(p.column)}: {self.kind} ..."
-            for p in self.positions
-        ]
+    def expected_str(self) -> Optional[List[str]]:
+        pos = self.positions
+        if pos:
+            return [
+                f"{_str_or_any(p.line)}:{_str_or_any(p.column)}: {self.kind} ..."
+                for p in pos
+            ]
 
-    def __post_init__(self):
+
+    def __post_init__(self) -> None:
         # Accept line and column in generated __init__ for compatibility with existing
         # test cases and add them into the positions list for new multiple report cases
         if self.positions is None:

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -9,7 +9,7 @@ import json
 import pkgutil
 import re
 import textwrap
-from dataclasses import dataclass, InitVar
+from dataclasses import InitVar, dataclass
 from pathlib import Path
 from types import ModuleType
 from typing import Dict, List, Optional, Set, Type, Union, cast
@@ -67,6 +67,7 @@ class ValidTestCase:
     filename: str = DEFAULT_FILENAME
     config: LintConfig = DEFAULT_CONFIG
 
+
 @add_slots
 @dataclass(frozen=True)
 class Position:
@@ -77,13 +78,14 @@ class Position:
     def position_str(self) -> str:
         return f"{_str_or_any(self.line)}:{_str_or_any(self.column)}"
 
+
 @add_slots
 @dataclass(frozen=True)
 class InvalidTestCase:
     code: str
     kind: Optional[str] = None
 
-    #can we mark these as deprecated?
+    # can we mark these as deprecated?
     line: Optional[int] = None
     column: Optional[int] = None
 
@@ -95,17 +97,23 @@ class InvalidTestCase:
 
     @property
     def expected_str(self) -> List[str]:
-        return [f"{_str_or_any(p.line)}:{_str_or_any(p.column)}: {self.kind} ..." for p in self.positions]
+        return [
+            f"{_str_or_any(p.line)}:{_str_or_any(p.column)}: {self.kind} ..."
+            for p in self.positions
+        ]
 
     def __post_init__(self):
-        #Accept line and column in generated __init__ for compatibility with existing
-        #test cases and add them into the positions list for new multiple report cases
+        # Accept line and column in generated __init__ for compatibility with existing
+        # test cases and add them into the positions list for new multiple report cases
         if self.positions is None:
-            object.__setattr__(self, 'positions', [Position(line=self.line, column=self.column)])
+            object.__setattr__(
+                self, "positions", [Position(line=self.line, column=self.column)]
+            )
 
-        #Maybe clean up the original properties down the line?
-        #object.__selattr__(self, 'line')
-        #object.__setattr__(self, 'column')
+        # Maybe clean up the original properties down the line?
+        # object.__selattr__(self, 'line')
+        # object.__setattr__(self, 'column')
+
 
 def import_submodules(package: str, recursive: bool = True) -> Dict[str, ModuleType]:
     """ Import all submodules of a module, recursively, including subpackages. """

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -104,7 +104,6 @@ class InvalidTestCase:
                 for p in pos
             ]
 
-
     def __post_init__(self) -> None:
         # Accept line and column in generated __init__ for compatibility with existing
         # test cases and add them into the positions list for new multiple report cases

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -9,7 +9,7 @@ import json
 import pkgutil
 import re
 import textwrap
-from dataclasses import InitVar, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 from typing import Dict, List, Optional, Set, Type, Union, cast
@@ -85,7 +85,7 @@ class InvalidTestCase:
     code: str
     kind: Optional[str] = None
 
-    # can we mark these as deprecated?
+    # should we mark these as deprecated?
     line: Optional[int] = None
     column: Optional[int] = None
 
@@ -111,8 +111,8 @@ class InvalidTestCase:
             )
 
         # Maybe clean up the original properties down the line?
-        # object.__selattr__(self, 'line')
-        # object.__setattr__(self, 'column')
+        # object.__setattr__(self, 'line', None)
+        # object.__setattr__(self, 'column', None)
 
 
 def import_submodules(package: str, recursive: bool = True) -> Dict[str, ModuleType]:


### PR DESCRIPTION
## Summary
Trying to supporting having lint autofix rules support multiple reports, so for instance you could change a variable named during assignment and have any subsequent access also updated, talking about this with Jimmy in workplace this is just a draft for discussion.

## Test Plan

