### PR TITLE
performance: speed up ignore comment detection

### DIFF
--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -43,10 +43,6 @@ LINT_IGNORE_REGEXP: Pattern[str] = re.compile(
     + r": (?P<codes>([-_a-zA-Z0-9]+,\s*)*[-_a-zA-Z0-9]+)"
     + r"(:( (?P<reason>.+)?)?)?"
 )
-HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = LINT_IGNORE_REGEXP
-HAS_LINT_IGNORE_OR_NOQA_REGEXP: Pattern[bytes] = re.compile(
-    b"|".join([LINT_IGNORE_REGEXP.pattern, NOQA_INLINE_REGEXP.pattern, NOQA_FILE_RULE.pattern, FLAKE8_NOQA_FILE.pattern])
-)
 
 # Skip evaluation of the given file.
 # People should use `# noqa-file` or `@no- lint` instead. This is here for compatibility
@@ -64,6 +60,17 @@ NOQA_FILE_RULE: Pattern[str] = re.compile(
     + r"(?P<reason>.+)"
 )
 
+HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = re.compile(LINT_IGNORE_REGEXP.pattern.encode())
+HAS_LINT_IGNORE_OR_NOQA_REGEXP: Pattern[bytes] = re.compile(
+    b"|".join(
+        [
+            LINT_IGNORE_REGEXP.pattern.encode(),
+            NOQA_INLINE_REGEXP.pattern.encode(),
+            NOQA_FILE_RULE.pattern.encode(),
+            FLAKE8_NOQA_FILE.pattern.encode(),
+        ]
+    )
+)
 
 LIST_SETTINGS = ["formatter", "block_list_patterns", "block_list_rules", "packages"]
 PATH_SETTINGS = ["repo_root", "fixture_dir"]

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -31,7 +31,7 @@ NOQA_INLINE_REGEXP: Pattern[str] = re.compile(
     # We do not care about the ``: `` that follows ``noqa``
     # We do not care about the casing of ``noqa``
     # We want a comma-separated list of errors
-    r"^# noqa(?!-file)(?:: (?P<codes>([a-zA-Z0-9]+,\s*)*[-_a-zA-Z0-9]+))?",
+    r"# noqa(?!-file)(?:: (?P<codes>([a-zA-Z0-9]+,\s*)*[-_a-zA-Z0-9]+))?",
     re.IGNORECASE,
 )
 LINT_IGNORE_REGEXP: Pattern[str] = re.compile(

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -62,7 +62,7 @@ NOQA_FILE_RULE: Pattern[str] = re.compile(
 
 
 def _remove_capturing_groups(regex: bytes) -> bytes:
-    return re.sub(rb"\?<\w+>", b"", regex)
+    return re.sub(rb"\?P<\w+>", b"", regex)
 
 
 HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = re.compile(LINT_IGNORE_REGEXP.pattern.encode())

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -45,7 +45,7 @@ LINT_IGNORE_REGEXP: Pattern[str] = re.compile(
 )
 HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = re.compile(rb"# lint-(ignore|fixme):")
 HAS_LINT_IGNORE_OR_NOQA_REGEXP: Pattern[bytes] = re.compile(
-    rb"# (lint-(ignore|fixme):|noqa)"
+    rb"# (lint-(ignore|fixme):|noqa|flake8)"
 )
 
 # Skip evaluation of the given file.

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -43,9 +43,9 @@ LINT_IGNORE_REGEXP: Pattern[str] = re.compile(
     + r": (?P<codes>([-_a-zA-Z0-9]+,\s*)*[-_a-zA-Z0-9]+)"
     + r"(:( (?P<reason>.+)?)?)?"
 )
-HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = re.compile(rb"# lint-(ignore|fixme):")
+HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = config.LINT_IGNORE_REGEXP
 HAS_LINT_IGNORE_OR_NOQA_REGEXP: Pattern[bytes] = re.compile(
-    rb"# (lint-(ignore|fixme):|noqa|flake8)"
+    b"|".join([config.LINT_IGNORE_REGEXP.pattern, config.NOQA_INLINE_REGEXP.pattern, config.NOQA_FILE_RULE.pattern, config.FLAKE8_NOQA_FILE.pattern])
 )
 
 # Skip evaluation of the given file.

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -74,7 +74,8 @@ HAS_LINT_IGNORE_OR_NOQA_REGEXP: Pattern[bytes] = re.compile(
             _remove_capturing_groups(NOQA_FILE_RULE.pattern.encode()),
             _remove_capturing_groups(FLAKE8_NOQA_FILE.pattern.encode()),
         ]
-    )
+    ),
+    re.IGNORECASE,
 )
 
 LIST_SETTINGS = ["formatter", "block_list_patterns", "block_list_rules", "packages"]

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -60,14 +60,19 @@ NOQA_FILE_RULE: Pattern[str] = re.compile(
     + r"(?P<reason>.+)"
 )
 
+
+def _remove_capturing_groups(regex: bytes) -> bytes:
+    return re.sub(rb"\?<\w+>", b"", regex)
+
+
 HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = re.compile(LINT_IGNORE_REGEXP.pattern.encode())
 HAS_LINT_IGNORE_OR_NOQA_REGEXP: Pattern[bytes] = re.compile(
     b"|".join(
         [
-            LINT_IGNORE_REGEXP.pattern.encode(),
-            NOQA_INLINE_REGEXP.pattern.encode(),
-            NOQA_FILE_RULE.pattern.encode(),
-            FLAKE8_NOQA_FILE.pattern.encode(),
+            _remove_capturing_groups(LINT_IGNORE_REGEXP.pattern.encode()),
+            _remove_capturing_groups(NOQA_INLINE_REGEXP.pattern.encode()),
+            _remove_capturing_groups(NOQA_FILE_RULE.pattern.encode()),
+            _remove_capturing_groups(FLAKE8_NOQA_FILE.pattern.encode()),
         ]
     )
 )

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -43,6 +43,10 @@ LINT_IGNORE_REGEXP: Pattern[str] = re.compile(
     + r": (?P<codes>([-_a-zA-Z0-9]+,\s*)*[-_a-zA-Z0-9]+)"
     + r"(:( (?P<reason>.+)?)?)?"
 )
+HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = re.compile(rb"# lint-(ignore|fixme):")
+HAS_LINT_IGNORE_OR_NOQA_REGEXP: Pattern[bytes] = re.compile(
+    rb"# (lint-(ignore|fixme):|noqa)"
+)
 
 # Skip evaluation of the given file.
 # People should use `# noqa-file` or `@no- lint` instead. This is here for compatibility

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -43,9 +43,9 @@ LINT_IGNORE_REGEXP: Pattern[str] = re.compile(
     + r": (?P<codes>([-_a-zA-Z0-9]+,\s*)*[-_a-zA-Z0-9]+)"
     + r"(:( (?P<reason>.+)?)?)?"
 )
-HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = config.LINT_IGNORE_REGEXP
+HAS_LINT_IGNORE_REGEXP: Pattern[bytes] = LINT_IGNORE_REGEXP
 HAS_LINT_IGNORE_OR_NOQA_REGEXP: Pattern[bytes] = re.compile(
-    b"|".join([config.LINT_IGNORE_REGEXP.pattern, config.NOQA_INLINE_REGEXP.pattern, config.NOQA_FILE_RULE.pattern, config.FLAKE8_NOQA_FILE.pattern])
+    b"|".join([LINT_IGNORE_REGEXP.pattern, NOQA_INLINE_REGEXP.pattern, NOQA_FILE_RULE.pattern, FLAKE8_NOQA_FILE.pattern])
 )
 
 # Skip evaluation of the given file.

--- a/fixit/common/ignores.py
+++ b/fixit/common/ignores.py
@@ -28,6 +28,8 @@ from fixit.common.base import CstLintRule
 from fixit.common.comments import CommentInfo
 from fixit.common.config import (
     FLAKE8_NOQA_FILE,
+    HAS_LINT_IGNORE_OR_NOQA_REGEXP,
+    HAS_LINT_IGNORE_REGEXP,
     LINT_IGNORE_REGEXP,
     NOQA_FILE_RULE,
     NOQA_INLINE_REGEXP,
@@ -283,3 +285,13 @@ class IgnoreInfo:
             # TODO: compute global suppression comments and merge them here
             local_ignore_info.local_suppression_comments,
         )
+
+
+def has_ignore_comments(source: bytes, *, use_noqa: bool) -> bool:
+    """Quick check to see if there are any ignore comments in the code.
+
+    This allow us to avoid having to tokenize all the files, which is a slow
+    operation.
+    """
+    pattern = HAS_LINT_IGNORE_OR_NOQA_REGEXP if use_noqa else HAS_LINT_IGNORE_REGEXP
+    return bool(pattern.search(source))

--- a/fixit/common/tests/test_ignores.py
+++ b/fixit/common/tests/test_ignores.py
@@ -410,6 +410,14 @@ class HasIgnoreCommentsTest(UnitTest):
                 "use_noqa": True,
                 "expected": True,
             },
+            "noqa_enabled_flake8": {
+                "source": b"""
+                    def foo():...
+                    # flake8:
+                    """,
+                "use_noqa": True,
+                "expected": True,
+            },
             "no_comments": {
                 "source": b"""
                     def foo():...

--- a/fixit/common/tests/test_ignores.py
+++ b/fixit/common/tests/test_ignores.py
@@ -381,7 +381,7 @@ class HasIgnoreCommentsTest(UnitTest):
             "lint_ignore": {
                 "source": b"""
                     def foo():...
-                    # lint-ignore:
+                    # lint-ignore: rule
                     """,
                 "use_noqa": False,
                 "expected": True,
@@ -389,7 +389,7 @@ class HasIgnoreCommentsTest(UnitTest):
             "lint_fixme": {
                 "source": b"""
                     def foo():...
-                    # lint-fixme:
+                    # lint-fixme: rule
                     """,
                 "use_noqa": False,
                 "expected": True,
@@ -397,7 +397,7 @@ class HasIgnoreCommentsTest(UnitTest):
             "noqa_disabled": {
                 "source": b"""
                     def foo():...
-                    # noqa
+                    # noqa: rule
                     """,
                 "use_noqa": False,
                 "expected": False,
@@ -405,7 +405,7 @@ class HasIgnoreCommentsTest(UnitTest):
             "noqa_enabled": {
                 "source": b"""
                     def foo():...
-                    # noqa
+                    # noqa: rule
                     """,
                 "use_noqa": True,
                 "expected": True,
@@ -413,7 +413,7 @@ class HasIgnoreCommentsTest(UnitTest):
             "noqa_enabled_flake8": {
                 "source": b"""
                     def foo():...
-                    # flake8:
+                    # flake8: noqa
                     """,
                 "use_noqa": True,
                 "expected": True,

--- a/fixit/common/tests/test_ignores.py
+++ b/fixit/common/tests/test_ignores.py
@@ -397,7 +397,7 @@ class HasIgnoreCommentsTest(UnitTest):
             "noqa_disabled": {
                 "source": b"""
                     def foo():...
-                    # noqa: rule
+                    # noqa-file: rule: reason
                     """,
                 "use_noqa": False,
                 "expected": False,
@@ -405,7 +405,7 @@ class HasIgnoreCommentsTest(UnitTest):
             "noqa_enabled": {
                 "source": b"""
                     def foo():...
-                    # noqa: rule
+                    # noqa-file: rule: reason
                     """,
                 "use_noqa": True,
                 "expected": True,
@@ -415,6 +415,11 @@ class HasIgnoreCommentsTest(UnitTest):
                     def foo():...
                     # flake8: noqa
                     """,
+                "use_noqa": True,
+                "expected": True,
+            },
+            "noqa_enabled_inline": {
+                "source": b"# noqa\ndef foo(): ...",
                 "use_noqa": True,
                 "expected": True,
             },

--- a/fixit/common/tests/test_ignores.py
+++ b/fixit/common/tests/test_ignores.py
@@ -12,7 +12,7 @@ import libcst as cst
 from libcst.testing.utils import UnitTest, data_provider
 
 from fixit.common.comments import CommentInfo
-from fixit.common.ignores import IgnoreInfo
+from fixit.common.ignores import IgnoreInfo, has_ignore_comments
 from fixit.common.line_mapping import LineMappingInfo
 from fixit.common.report import CstLintRuleReport
 from fixit.common.utils import dedent_with_lstrip
@@ -373,3 +373,57 @@ class IgnoreInfoTest(UnitTest):
             self.assertEqual(len(supp_comments), 1)
             supp_comment = supp_comments[0]
             self.assertIs(supp_comment, local_supp_comment)
+
+
+class HasIgnoreCommentsTest(UnitTest):
+    @data_provider(
+        {
+            "lint_ignore": {
+                "source": b"""
+                    def foo():...
+                    # lint-ignore:
+                    """,
+                "use_noqa": False,
+                "expected": True,
+            },
+            "lint_fixme": {
+                "source": b"""
+                    def foo():...
+                    # lint-fixme:
+                    """,
+                "use_noqa": False,
+                "expected": True,
+            },
+            "noqa_disabled": {
+                "source": b"""
+                    def foo():...
+                    # noqa
+                    """,
+                "use_noqa": False,
+                "expected": False,
+            },
+            "noqa_enabled": {
+                "source": b"""
+                    def foo():...
+                    # noqa
+                    """,
+                "use_noqa": True,
+                "expected": True,
+            },
+            "no_comments": {
+                "source": b"""
+                    def foo():...
+                    """,
+                "use_noqa": False,
+                "expected": False,
+            },
+        }
+    )
+    def test_has_ignore_comments(
+        self,
+        *,
+        source: bytes,
+        use_noqa: bool,
+        expected: bool,
+    ) -> None:
+        self.assertEqual(has_ignore_comments(source, use_noqa=use_noqa), expected)

--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -15,7 +15,7 @@ from libcst.metadata import MetadataWrapper
 from fixit.common.base import CstContext, CstLintRule, LintConfig
 from fixit.common.comments import CommentInfo
 from fixit.common.config import get_lint_config
-from fixit.common.ignores import IgnoreInfo
+from fixit.common.ignores import IgnoreInfo, has_ignore_comments
 from fixit.common.line_mapping import LineMappingInfo
 from fixit.common.pseudo_rule import PseudoContext, PseudoLintRule
 from fixit.common.report import BaseLintRuleReport
@@ -75,7 +75,7 @@ def lint_file(
         return []
 
     tokens = None
-    if use_ignore_comments:
+    if use_ignore_comments and has_ignore_comments(source, use_noqa=config.use_noqa):
         # Don't compute tokens unless we have to, it slows down
         # `fixit.cli.run_rules`.
         #


### PR DESCRIPTION
## Summary
Tokenizing a file is quite slow, as the module is implemented in pure python. So, instead of always tokenizing the files when use_noqa is set, we will first use a fast regex.

The following command on the LibCST repo went from 26 seconds to 17 seconds.
fixit run_rules --rules RewriteToLiteralRule UseAssertInRule UseFstringRule NoRedundantFStringRule

## Test Plan
Unit test for the new code and maybe some manual testing to verify the speed improvement claims