### PR TITLE
performance: improve wrapper build

### DIFF
--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -130,6 +130,7 @@ def lint_file(
         # filter the accumulated errors that should be suppressed and report unused suppressions
         reports = [r for r in reports if not ignore_info.should_ignore_report(r)]
         if find_unused_suppressions and cst_rules:
+            assert cst_wrapper is not None
             # We had to make sure to call ignore_info.should_ignore_report before running our
             # RemoveUnusedSuppressionsRule because ignore_info needs to be up to date for it to work.
             # We can construct a new context since we want a fresh set of reports to append to reports.

--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -38,6 +38,9 @@ def _visit_cst_rules_with_context(
     rule_instances = [r(context) for r in rules]
     rule_instances = [r for r in rule_instances if not r.should_skip_file()]
 
+    if not rule_instances:
+        return
+
     # before_visit/after_leave are used to update the context
     def before_visit(node: cst.CSTNode) -> None:
         context.node_stack.append(node)
@@ -108,9 +111,12 @@ def lint_file(
     ast_tree = None
     reports = []
 
-    if cst_wrapper is None:
-        cst_wrapper = MetadataWrapper(cst.parse_module(source), unsafe_skip_copy=True)
     if cst_rules:
+        if cst_wrapper is None:
+            cst_wrapper = MetadataWrapper(
+                cst.parse_module(source), unsafe_skip_copy=True
+            )
+
         cst_context = CstContext(cst_wrapper, source, file_path, config)
         _visit_cst_rules_with_context(cst_wrapper, cst_rules, cst_context)
         reports.extend(cst_context.reports)


### PR DESCRIPTION
## Summary
The metadata wrapper is not needed in case there are no cst_rules.

With this change we improve the following command on LibCST from 10.69 seconds to 5.69 seconds.

fixit run_rules --rules Flake8PseudoLintRule
## Test Plan

