### PR TITLE
Expose `ipc_main` with arguments instead of argparse

### DIFF
--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -199,7 +199,16 @@ class IPCResult:
     paths: List[str]
 
 
-def ipc(opts: LintOpts, paths: List[str], prefix: str = None, workers: LintWorkers) -> IPCResult:
+def run_ipc(opts: LintOpts, paths: List[str], prefix: str = None, workers: LintWorkers) -> IPCResult:
+    """
+    Given a LintOpts config with lint rules and lint success/failure report formatter,
+    this IPC helper takes a path of source files (with an optional `prefix` that will be prepended).
+    Results are formed as JSON and delimited by newlines.
+    It uses a multiprocess pool and the results are streamed to stdout as soon
+    as they're available.
+
+    Returns an IPCResult object.
+    """
     if workers is None:
         workers = LintWorkers.CPU_COUNT
 
@@ -230,11 +239,9 @@ def ipc(opts: LintOpts, paths: List[str], prefix: str = None, workers: LintWorke
 
 def ipc_main(opts: LintOpts) -> IPCResult:
     """
-    Given a LintOpts config with lint rules and lint success/failure report formatter,
-    this IPC helper took paths of source files from either a path file (with @paths arg)
-    or a list of paths as args. Results are formed as JSON and delimited by newlines.
-    It uses a multiprocess pool and the results are streamed to stdout as soon
-    as they're available.
+    Like `run_ipc` instead this function expects arguments to be collected through argparse.
+    This IPC helper takes paths of source files from either a path file (with @paths arg)
+    or a list of paths as args.
 
     Returns an IPCResult object.
     """
@@ -247,4 +254,4 @@ def ipc_main(opts: LintOpts) -> IPCResult:
     parser.add_argument("--prefix", help="A prefix to be added to all paths.")
     args: argparse.Namespace = parser.parse_args()
 
-    return ipc(ops=ops, paths=args.paths, prefix=args.prefix, workers=args.workers)
+    return run_ipc(ops=ops, paths=args.paths, prefix=args.prefix, workers=args.workers)

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -199,7 +199,9 @@ class IPCResult:
     paths: List[str]
 
 
-def run_ipc(opts: LintOpts, paths: List[str], prefix: str = None, workers: LintWorkers) -> IPCResult:
+def run_ipc(
+    opts: LintOpts, paths: List[str], prefix: str = None, workers: LintWorkers = None
+) -> IPCResult:
     """
     Given a LintOpts config with lint rules and lint success/failure report formatter,
     this IPC helper takes a path of source files (with an optional `prefix` that will be prepended).
@@ -254,4 +256,6 @@ def ipc_main(opts: LintOpts) -> IPCResult:
     parser.add_argument("--prefix", help="A prefix to be added to all paths.")
     args: argparse.Namespace = parser.parse_args()
 
-    return run_ipc(ops=ops, paths=args.paths, prefix=args.prefix, workers=args.workers)
+    return run_ipc(
+        opts=opts, paths=args.paths, prefix=args.prefix, workers=args.workers
+    )

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -12,6 +12,7 @@ import json
 import multiprocessing
 import os
 import traceback
+import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import (
@@ -46,7 +47,6 @@ from fixit.rule_lint_engine import lint_file
 
 if TYPE_CHECKING:
     from libcst.metadata.base_provider import ProviderT
-
 
 _MapPathsOperationConfigT = TypeVar("_MapPathsOperationConfigT")
 _MapPathsOperationResultT = TypeVar("_MapPathsOperationResultT")
@@ -242,12 +242,19 @@ def run_ipc(
 
 def ipc_main(opts: LintOpts) -> IPCResult:
     """
-    Like `run_ipc` instead this function expects arguments to be collected through argparse.
-    This IPC helper takes paths of source files from either a path file (with @paths arg)
-    or a list of paths as args.
+    Like `run_ipc` instead this function expects arguments to be collected through
+    argparse. This IPC helper takes paths of source files from either a path file
+    (with @paths arg) or a list of paths as args.
 
     Returns an IPCResult object.
     """
+    warnings.warn(
+        """
+        Calling ipc_main as a command line tool is being deprecated.
+        Please use the module-level function `run_ipc` instead.""",
+        DeprecationWarning,
+    )
+
     parser = argparse.ArgumentParser(
         description="Runs Fixit lint rules and print results as console output.",
         fromfile_prefix_chars="@",

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -200,7 +200,10 @@ class IPCResult:
 
 
 def run_ipc(
-    opts: LintOpts, paths: List[str], prefix: str = None, workers: LintWorkers = None
+    opts: LintOpts,
+    paths: List[str],
+    prefix: Optional[str] = None,
+    workers: LintWorkers = LintWorkers.CPU_COUNT,
 ) -> IPCResult:
     """
     Given a LintOpts config with lint rules and lint success/failure report formatter,
@@ -211,8 +214,6 @@ def run_ipc(
 
     Returns an IPCResult object.
     """
-    if workers is None:
-        workers = LintWorkers.CPU_COUNT
 
     paths: Generator[str, None, None] = (
         os.path.join(prefix, p) if prefix else p for p in paths
@@ -236,7 +237,7 @@ def run_ipc(
         for result in results:
             print(result)
 
-    return IPCResult(paths)
+    return IPCResult(list(paths))
 
 
 def ipc_main(opts: LintOpts) -> IPCResult:

--- a/fixit/cli/tests/test_ipc.py
+++ b/fixit/cli/tests/test_ipc.py
@@ -1,0 +1,99 @@
+import contextlib
+import io
+import json
+import tempfile
+
+from libcst.testing.utils import UnitTest
+
+from fixit.cli import run_ipc
+from fixit.cli.args import LintWorkers
+from fixit.cli.tests.test_lint_opts import generate_mock_lint_opt
+
+
+TARGET_PATH = None
+EXPECTED_SUCCESS_REPORT = json.loads(
+    """{"path": "fill-this-out", "status": "success", "reports": ["fake picklable report"]}"""
+)
+EXPECTED_FAILURE_REPORT = json.loads(
+    """{"path": "fill-this-out", "status": "failure", "reports": ["fake picklable report"]}"""
+)
+
+
+class IpcTest(UnitTest):
+    def setUp(self) -> None:
+        self.opts = generate_mock_lint_opt()
+
+    def test_single_path_ipc(self) -> None:
+        with io.StringIO() as buffer, tempfile.NamedTemporaryFile(
+            "w+"
+        ) as fd, contextlib.redirect_stdout(buffer):
+            # create a valid file for the test to run against
+            fd.write("""test_str = 'hello world'""")
+            fd.flush()
+            path = fd.name
+
+            run_ipc(
+                opts=self.opts, paths=[path], workers=LintWorkers.USE_CURRENT_THREAD
+            )
+
+            # get values from the buffer before we close it
+            buffer.flush()
+            output = buffer.getvalue()
+
+        report = json.loads(output)
+
+        target_report = EXPECTED_SUCCESS_REPORT.copy()
+        target_report["path"] = path
+
+        self.assertDictEqual(report, target_report)
+
+    def test_multi_path_ipc(self) -> None:
+        with io.StringIO() as buffer, tempfile.NamedTemporaryFile(
+            "w+"
+        ) as fd_a, tempfile.NamedTemporaryFile(
+            "w+"
+        ) as fd_b, contextlib.redirect_stdout(
+            buffer
+        ):
+            # create a valid file for the test to run against
+            fd_a.write("""test_str = 'hello world'""")
+            fd_a.flush()
+
+            # now create an invalid one
+            # mismatched tab-indent will do the trick
+            fd_b.write("""\ta = 1\nb = 2""")
+            fd_b.flush()
+            path_a = fd_a.name
+            path_b = fd_b.name
+
+            # this path doesn't exist at all, but the runner should still handle it gracefully
+            path_c = "/does/not/exist.tmp"
+
+            run_ipc(
+                opts=self.opts,
+                paths=[path_a, path_b, path_c],
+                workers=LintWorkers.USE_CURRENT_THREAD,
+            )
+
+            # get values from the buffer before we close it
+            buffer.flush()
+            output = buffer.getvalue()
+
+        # each report is separated by a new-line
+        reports = output.strip().split("\n")
+        print("split", reports)
+        self.assertEqual(len(reports), 3)
+        report_a, report_b, report_c = [json.loads(report) for report in reports]
+
+        target_report_a = EXPECTED_SUCCESS_REPORT.copy()
+        target_report_a["path"] = path_a
+
+        target_report_b = EXPECTED_FAILURE_REPORT.copy()
+        target_report_b["path"] = path_b
+
+        target_report_c = EXPECTED_FAILURE_REPORT.copy()
+        target_report_c["path"] = path_c
+
+        self.assertDictEqual(report_a, target_report_a)
+        self.assertDictEqual(report_b, target_report_b)
+        self.assertDictEqual(report_c, target_report_c)

--- a/fixit/cli/tests/test_ipc.py
+++ b/fixit/cli/tests/test_ipc.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import contextlib
 import io
 import json

--- a/fixit/cli/tests/test_ipc.py
+++ b/fixit/cli/tests/test_ipc.py
@@ -7,6 +7,7 @@ import contextlib
 import io
 import json
 import tempfile
+from typing import Any, Dict
 
 from libcst.testing.utils import UnitTest
 
@@ -15,11 +16,10 @@ from fixit.cli.args import LintWorkers
 from fixit.cli.tests.test_lint_opts import generate_mock_lint_opt
 
 
-TARGET_PATH = None
-EXPECTED_SUCCESS_REPORT = json.loads(
+EXPECTED_SUCCESS_REPORT: Dict[str, Any] = json.loads(
     """{"path": "fill-this-out", "status": "success", "reports": ["fake picklable report"]}"""
 )
-EXPECTED_FAILURE_REPORT = json.loads(
+EXPECTED_FAILURE_REPORT: Dict[str, Any] = json.loads(
     """{"path": "fill-this-out", "status": "failure", "reports": ["fake picklable report"]}"""
 )
 

--- a/fixit/cli/tests/test_lint_opts.py
+++ b/fixit/cli/tests/test_lint_opts.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Collection, List, Sequence, cast
+from typing import Collection, List, Optional, Sequence, cast
 
 from libcst import Module
 from libcst.testing.utils import UnitTest
@@ -71,7 +71,7 @@ def mock_operation(
     return cast(Sequence[FakeLintSuccessReport], results)
 
 
-def generate_mock_lint_opt(global_list=None):
+def generate_mock_lint_opt(global_list: Optional[List[str]] = None) -> LintOpts:
     if global_list is None:
         global_list = []
 


### PR DESCRIPTION
## Summary

Refactored `ipc_main` into `run_ipc` which takes in arguments instead of relying on argparse. `ipc_main` still exists for backwards compatibility. 

## Test Plan

Added a test verifying that
1. The new function runs on a single path and returns output as expected
2. The new function still supports reporting on multiple input paths

Ran `tox -e py38` to verify tests were running and green.
