### PR TITLE
Only change builtin types in `UseTypesFromTypingRule`

### DIFF
--- a/fixit/rules/use_types_from_typing.py
+++ b/fixit/rules/use_types_from_typing.py
@@ -6,10 +6,7 @@
 from typing import Set
 
 import libcst
-from libcst.metadata import (
-    QualifiedNameProvider,
-    ScopeProvider,
-)
+from libcst.metadata import QualifiedNameProvider, ScopeProvider
 
 from fixit import (
     CstContext,


### PR DESCRIPTION
# Problem
`UseTypesFromTypingRule` incorrectly changed list to List in this real-world snippet:

```
from typing import List as list
from graphene import List

def function(a: list[int]) -> List[int]:
    return []
```

# Solution

Refine the check to confirm the node is a builtin

# Test Plan
Added test and ran `tox -e py38 -- fixit.tests.UseTypesFromTypingRule`