### PR TITLE
Supports passing no providers to FullRepoMetadataConfig.

### DIFF
--- a/fixit/common/full_repo_metadata.py
+++ b/fixit/common/full_repo_metadata.py
@@ -53,7 +53,7 @@ def get_repo_caches(
     caches = {}
     paths_iter = iter(paths)
     head: Optional[str] = next(paths_iter, None)
-    placeholder: bool = False if config.providers else True
+    placeholder: bool = not config.providers
     while head is not None:
         paths_batch = tuple(chain([head], islice(paths_iter, config.batch_size - 1)))
         head = next(paths_iter, None)

--- a/fixit/common/full_repo_metadata.py
+++ b/fixit/common/full_repo_metadata.py
@@ -81,9 +81,7 @@ def get_repo_caches(
             caches.update(
                 dict.fromkeys(
                     paths_batch,
-                    {
-                        TypeInferenceProvider: PLACEHOLDER_CACHES[TypeInferenceProvider]
-                    },
+                    {TypeInferenceProvider: PLACEHOLDER_CACHES[TypeInferenceProvider]},
                 )
             )
         else:

--- a/fixit/common/tests/test_full_repo_metadata.py
+++ b/fixit/common/tests/test_full_repo_metadata.py
@@ -99,8 +99,8 @@ class FullRepoMetadataTest(UnitTest):
 
     @patch("libcst.metadata.TypeInferenceProvider.gen_cache")
     def test_get_repo_caches_empty_providers(self, gen_cache: MagicMock) -> None:
-        repo_caches: Mapping[str, Dict[ProviderT, object]] = get_repo_caches(
-            (self.DUMMY_PATH,), FullRepoMetadataConfig({}, 1)
+        repo_caches = get_repo_caches(
+            (self.DUMMY_PATH,), FullRepoMetadataConfig(set(), 1)
         )
 
         self.assertEqual(

--- a/fixit/common/tests/test_full_repo_metadata.py
+++ b/fixit/common/tests/test_full_repo_metadata.py
@@ -96,3 +96,13 @@ class FullRepoMetadataTest(UnitTest):
         )
 
         self.assertEqual(CustomHandler.errors, {TimeoutExpired: [self.DUMMY_PATH]})
+
+    @patch("libcst.metadata.TypeInferenceProvider.gen_cache")
+    def test_get_repo_caches_empty_providers(self, gen_cache: MagicMock) -> None:
+        repo_caches: Mapping[str, Dict[ProviderT, object]] = get_repo_caches(
+            (self.DUMMY_PATH,), FullRepoMetadataConfig({}, 1)
+        )
+
+        self.assertEqual(
+            repo_caches, {self.DUMMY_PATH: {TypeInferenceProvider: {"types": []}}}
+        )


### PR DESCRIPTION
## Summary
https://github.com/Instagram/Fixit/issues/181

Allowing passing no providers to FullRepoMetadata. There is already a fallback if the provider is broken where a placeholder cache is used, so I used the same codepath to treat empty providers and exceptions the same way.

There is currently only one placeholder cache type so I hardcoded TypeInferenceProvider, but if we want this to be more flexible I can try to build support for multiple.

## Test Plan

Added a unit test. Tested manually and exception no longer fires and linters work correctly.
