### PR TITLE
Sentinel type error

### DIFF
--- a/fixit/common/autofix.py
+++ b/fixit/common/autofix.py
@@ -174,9 +174,7 @@ def _replace_or_remove(
     original_node: cst.CSTNode,
     replacement_node: Union[cst.CSTNode, cst.FlattenSentinel, cst.RemovalSentinel],
 ) -> cst.CSTNode:
-    if isinstance(replacement_node, cst.RemovalSentinel) or isinstance(
-        replacement_node, cst.FlattenSentinel
-    ):
+    if isinstance(replacement_node, (cst.RemovalSentinel, cst.FlattenSentinel)):
         return cst.ensure_type(parent.deep_remove(original_node), cst.CSTNode)
     else:
         return parent.deep_replace(original_node, replacement_node)

--- a/fixit/common/autofix.py
+++ b/fixit/common/autofix.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Union
 
 import libcst as cst
+from libcst import FlattenSentinel
 from libcst.metadata import (
     CodePosition,
     ExperimentalReentrantCodegenProvider,
@@ -34,7 +35,7 @@ class LintPatch:
     def get(
         wrapper: MetadataWrapper,
         original_node: cst.CSTNode,
-        replacement_node: Union[cst.CSTNode, cst.RemovalSentinel],
+        replacement_node: Union[cst.CSTNode, FlattenSentinel, cst.RemovalSentinel],
     ) -> "LintPatch":
         # Batch the execution of these position providers
         wrapper.resolve_many(
@@ -172,9 +173,11 @@ class LintPatch:
 def _replace_or_remove(
     parent: cst.CSTNode,
     original_node: cst.CSTNode,
-    replacement_node: Union[cst.CSTNode, cst.RemovalSentinel],
+    replacement_node: Union[cst.CSTNode, cst.FlattenSentinel, cst.RemovalSentinel],
 ) -> cst.CSTNode:
-    if isinstance(replacement_node, cst.RemovalSentinel):
+    if isinstance(replacement_node, cst.RemovalSentinel) or isinstance(
+        replacement_node, cst.FlattenSentinel
+    ):
         return cst.ensure_type(parent.deep_remove(original_node), cst.CSTNode)
     else:
         return parent.deep_replace(original_node, replacement_node)

--- a/fixit/common/autofix.py
+++ b/fixit/common/autofix.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Union
 
 import libcst as cst
-from libcst import FlattenSentinel
 from libcst.metadata import (
     CodePosition,
     ExperimentalReentrantCodegenProvider,
@@ -35,7 +34,7 @@ class LintPatch:
     def get(
         wrapper: MetadataWrapper,
         original_node: cst.CSTNode,
-        replacement_node: Union[cst.CSTNode, FlattenSentinel, cst.RemovalSentinel],
+        replacement_node: Union[cst.CSTNode, cst.FlattenSentinel, cst.RemovalSentinel],
     ) -> "LintPatch":
         # Batch the execution of these position providers
         wrapper.resolve_many(

--- a/fixit/common/base.py
+++ b/fixit/common/base.py
@@ -117,7 +117,9 @@ class CstLintRule(BatchableCSTVisitor, metaclass=ABCMeta):
         message: Optional[str] = None,
         *,
         position: Optional[CodePosition] = None,
-        replacement: Optional[Union[cst.CSTNode, cst.RemovalSentinel]] = None,
+        replacement: Optional[
+            Union[cst.CSTNode, cst.RemovalSentinel, cst.FlattenSentinel]
+        ] = None,
     ) -> None:
         """
         Report a lint violation for a given node. Optionally specify a custom

--- a/fixit/common/report.py
+++ b/fixit/common/report.py
@@ -83,7 +83,9 @@ class CstLintRuleReport(BaseLintRuleReport):
         column: int,
         module: cst.MetadataWrapper,
         module_bytes: bytes,
-        replacement_node: Optional[Union[cst.CSTNode, cst.RemovalSentinel]] = None,
+        replacement_node: Optional[
+            Union[cst.CSTNode, cst.FlattenSentinel, cst.RemovalSentinel]
+        ] = None,
     ) -> None:
         super().__init__(
             file_path=file_path, code=code, message=message, line=line, column=column

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flake8>=3.8.1
-libcst>=0.3.10
+libcst>=0.3.18
 pyyaml>=5.2

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
 commands =
     isort -q {posargs:.}
     black {posargs:.}
+    python -m fixit.cli.apply_fix {posargs:.}
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
## Summary
Pyre is broken on master due to changes in the latest version of LibCST. This fixes by adding `cst.FlattenSentinel` to some function calls.

https://github.com/Instagram/Fixit/issues/186

## Test Plan
`pyre --preserve-pythonpath check`

