### PR TITLE
Autofixes three module doscstrings.

### DIFF
--- a/fixit/cli/add_new_rule.py
+++ b/fixit/cli/add_new_rule.py
@@ -57,7 +57,7 @@ class {class_name}Rule(CstLintRule):
 
 
 def is_path_exists(path: str) -> Path:
-    """Check for valid path, if yes, return `Path` else raise `Error` """
+    """Check for valid path, if yes, return `Path` else raise `Error`"""
     filepath = Path(path)
     if filepath.exists():
         raise FileExistsError(f"{filepath} already exists")
@@ -68,7 +68,7 @@ def is_path_exists(path: str) -> Path:
 
 
 def is_valid_name(name: str) -> str:
-    """Check for valid rule name """
+    """Check for valid rule name"""
     if name.casefold().endswith(("rule", "rules")):
         raise ValueError("Please enter rule name without the suffix, 'rule' or 'Rule'")
     return snake_to_camelcase(name)
@@ -89,7 +89,7 @@ def create_rule_file(file_path: Path, rule_name: str) -> None:
 
 
 def _add_arguments(parser: argparse.ArgumentParser) -> None:
-    """All required arguments for `add_new_rule` """
+    """All required arguments for `add_new_rule`"""
     parser.add_argument(
         "--path",
         type=is_path_exists,

--- a/fixit/common/unused_suppressions.py
+++ b/fixit/common/unused_suppressions.py
@@ -62,7 +62,7 @@ def _compose_new_comment(
 def _get_unused_codes_in_comment(
     local_supp_comment: SuppressionComment, ignored_rules_that_ran: Collection[str]
 ) -> Collection[str]:
-    """ Returns a subset of the rules in the comment which did not show up in any report. """
+    """Returns a subset of the rules in the comment which did not show up in any report."""
     return {
         ir
         for ir in ignored_rules_that_ran

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -86,7 +86,7 @@ class InvalidTestCase:
 
 
 def import_submodules(package: str, recursive: bool = True) -> Dict[str, ModuleType]:
-    """ Import all submodules of a module, recursively, including subpackages. """
+    """Import all submodules of a module, recursively, including subpackages."""
     package: ModuleType = importlib.import_module(package)
     results = {}
     # pyre-fixme[16]: `ModuleType` has no attribute `__path__`.


### PR DESCRIPTION
## Summary
For some reason `autofix` want to remove this trailing space and it is causing breakages on all of my PRs. Updating the space in its own separate PR here.
## Test Plan
`tox -e autofix`
