### PR TITLE
Reads use_noqa from config file.

### DIFF
--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -63,14 +63,12 @@ NOQA_FILE_RULE: Pattern[str] = re.compile(
 
 LIST_SETTINGS = ["formatter", "block_list_patterns", "block_list_rules", "packages"]
 PATH_SETTINGS = ["repo_root", "fixture_dir"]
+BOOLEAN_SETTINGS = ["use_noqa"]
 NESTED_SETTINGS = ["rule_config"]
 DEFAULT_FORMATTER = ["black", "-"]
 
 
-def get_validated_settings(
-    file_content: Dict[str, Any], current_dir: Path
-) -> Dict[str, Any]:
-    settings = {}
+def _set_list_settings(settings: Dict[str, Any], file_content: Dict[str, Any]) -> None:
     for list_setting_name in LIST_SETTINGS:
         if list_setting_name in file_content:
             if not (
@@ -81,6 +79,11 @@ def get_validated_settings(
                     f"Expected list of strings for `{list_setting_name}` setting."
                 )
             settings[list_setting_name] = file_content[list_setting_name]
+
+
+def _set_path_settings(
+    settings: Dict[str, Any], file_content: Dict[str, Any], current_dir: Path
+) -> None:
     for path_setting_name in PATH_SETTINGS:
         if path_setting_name in file_content:
             setting_value = file_content[path_setting_name]
@@ -92,6 +95,10 @@ def get_validated_settings(
         # Set path setting to absolute path.
         settings[path_setting_name] = str(abspath)
 
+
+def _set_nested_settings(
+    settings: Dict[str, Any], file_content: Dict[str, Any]
+) -> None:
     for nested_setting_name in NESTED_SETTINGS:
         if nested_setting_name in file_content:
             nested_setting = file_content[nested_setting_name]
@@ -108,6 +115,28 @@ def get_validated_settings(
                     )
                 settings[nested_setting_name].update({k: v})
 
+
+def _set_boolean_settings(
+    settings: Dict[str, Any], file_content: Dict[str, Any]
+) -> None:
+    for boolean_setting_name in BOOLEAN_SETTINGS:
+        if boolean_setting_name in file_content:
+            setting_value = file_content[boolean_setting_name]
+            if not isinstance(setting_value, bool):
+                raise TypeError(
+                    f"Expected boolean for `{boolean_setting_name}` setting."
+                )
+            settings[boolean_setting_name] = setting_value
+
+
+def get_validated_settings(
+    file_content: Dict[str, Any], current_dir: Path
+) -> Dict[str, Any]:
+    settings = {}
+    _set_list_settings(settings, file_content)
+    _set_path_settings(settings, file_content, current_dir)
+    _set_nested_settings(settings, file_content)
+    _set_boolean_settings(settings, file_content)
     return settings
 
 

--- a/fixit/common/tests/test_config.py
+++ b/fixit/common/tests/test_config.py
@@ -1,0 +1,57 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+import os
+from pathlib import Path
+
+from libcst.testing.utils import UnitTest
+
+from fixit.common.config import (
+    BOOLEAN_SETTINGS,
+    LIST_SETTINGS,
+    NESTED_SETTINGS,
+    PATH_SETTINGS,
+    get_validated_settings,
+)
+
+
+TEST_CONFIG = {
+    "formatter": ["black", "-", "--no-diff"],
+    "packages": ["python.fixit.rules"],
+    "block_list_rules": ["Flake8PseudoLintRule"],
+    "fixture_dir": f"{os.getcwd()}",
+    "repo_root": f"{os.getcwd()}",
+    "use_noqa": False,
+    "rule_config": {
+        "UnusedImportsRule": {
+            "ignored_unused_modules": [
+                "__future__",
+                "__static__",
+                "__static__.compiler_flags",
+                "__strict__",
+            ]
+        },
+    },
+}
+
+
+class TestConfig(UnitTest):
+    def test_get_validated_settings(self) -> None:
+        settings = get_validated_settings(TEST_CONFIG, Path("."))
+        settings_options = list(
+            itertools.chain(
+                BOOLEAN_SETTINGS, LIST_SETTINGS, PATH_SETTINGS, NESTED_SETTINGS
+            )
+        )
+        # Assert all the settings are set
+        self.assertTrue(all(setting in settings_options for setting in settings.keys()))
+
+    def test_get_validated_settings_raises_type_error(self) -> None:
+        TEST_CONFIG["use_noqa"] = "Yes"  # set the wrong type
+        with self.assertRaisesRegex(
+            TypeError, r"Expected boolean for `use_noqa` setting\."
+        ):
+            get_validated_settings(TEST_CONFIG, Path("."))

--- a/fixit/common/tests/test_config.py
+++ b/fixit/common/tests/test_config.py
@@ -46,8 +46,10 @@ class TestConfig(UnitTest):
                 BOOLEAN_SETTINGS, LIST_SETTINGS, PATH_SETTINGS, NESTED_SETTINGS
             )
         )
-        # Assert all the settings are set
+        # Assert all the setting keys are present
         self.assertTrue(all(setting in settings_options for setting in settings.keys()))
+        # Assert everything has been set as expected
+        self.assertEqual(TEST_CONFIG, settings)
 
     def test_get_validated_settings_raises_type_error(self) -> None:
         TEST_CONFIG["use_noqa"] = "Yes"  # set the wrong type


### PR DESCRIPTION
## Summary
https://github.com/Instagram/Fixit/issues/191
`use_noqa` is not taking effect because the setting is not read from the config file, this diff fixes that by adding a `BOOLEAN_SETTINGS` option and looping through that.

`get_validated_settings` became too complicated (according to the linter) with this addition, so I separated it out into different functions.

## Test Plan
Added some unit tests, ran `tox`
