### PR TITLE
Fixes pyre type-check errors.

### DIFF
--- a/fixit/common/generate_pyre_fixtures.py
+++ b/fixit/common/generate_pyre_fixtures.py
@@ -6,7 +6,6 @@
 import argparse
 import json
 import tempfile
-import shlex
 from pathlib import Path
 from typing import cast, List
 

--- a/fixit/common/generate_pyre_fixtures.py
+++ b/fixit/common/generate_pyre_fixtures.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import tempfile
 from pathlib import Path
-from typing import cast, List
+from typing import List, cast
 
 from libcst.metadata.type_inference_provider import (
     PyreData,

--- a/fixit/common/generate_pyre_fixtures.py
+++ b/fixit/common/generate_pyre_fixtures.py
@@ -6,8 +6,9 @@
 import argparse
 import json
 import tempfile
+import shlex
 from pathlib import Path
-from typing import cast
+from typing import cast, List
 
 from libcst.metadata.type_inference_provider import (
     PyreData,
@@ -33,10 +34,10 @@ class RuleTypeError(Exception):
 
 
 class PyreQueryError(Exception):
-    def __init__(self, command: str, message: str) -> None:
+    def __init__(self, command: List[str], message: str) -> None:
         super().__init__(
             "Unable to infer types from temporary file. "
-            + f"Command `{command}` returned with the following message: {message}."
+            + f"Command `{' '.join(command)}` returned with the following message: {message}."
         )
 
 
@@ -50,7 +51,7 @@ def gen_types_for_test_case(source_code: str, dest_path: Path) -> None:
         temp.write(_dedent(source_code))
         temp.seek(0)
 
-        cmd = f'''pyre query "types(path='{temp.name}')"'''
+        cmd = ["pyre", "query", f'''"types(path='{temp.name}')"''']
         stdout, stderr, return_code = run_command(cmd)
         if return_code != 0:
             raise PyreQueryError(cmd, f"{stdout}\n{stderr}")
@@ -72,7 +73,7 @@ def gen_types(rule: CstLintRule, rule_fixture_dir: Path) -> None:
     if hasattr(rule, "VALID") or hasattr(rule, "INVALID"):
         print("Starting pyre server")
 
-        stdout, stderr, return_code = run_command("pyre start")
+        stdout, stderr, return_code = run_command(["pyre", "start"])
         if return_code != 0:
             print(stdout)
             print(stderr)
@@ -86,7 +87,7 @@ def gen_types(rule: CstLintRule, rule_fixture_dir: Path) -> None:
                 for idx, invalid_tc in enumerate(getattr(rule, "INVALID")):
                     path: Path = rule_fixture_dir / f"{class_name}_INVALID_{idx}.json"
                     gen_types_for_test_case(source_code=invalid_tc.code, dest_path=path)
-            run_command("pyre stop")
+            run_command(["pyre", "stop"])
 
 
 def get_fixture_path(

--- a/fixit/rules/cls_in_classmethod.py
+++ b/fixit/rules/cls_in_classmethod.py
@@ -22,7 +22,7 @@ CLS = "cls"
 
 class _RenameTransformer(cst.CSTTransformer):
     def __init__(
-        self, names: List[Union[cst.Name, cst.Attribute]], new_name: str
+        self, names: List[Union[cst.Name, cst.BaseString, cst.Attribute]], new_name: str
     ) -> None:
         self.names = names
         self.new_name = new_name
@@ -269,7 +269,7 @@ class UseClsInClassmethodRule(CstLintRule):
             self.report(node)
             return
 
-        refs: List[Union[cst.Name, cst.Attribute]] = []
+        refs: List[Union[cst.Name, cst.Attribute, cst.BaseString]] = []
         assignments = scope[p0_name.value]
         for a in assignments:
             if isinstance(a, Assignment):


### PR DESCRIPTION
## Summary
New type errors introduced with the new LibCST version. `run_command` now takes a list, and `cst.BaseString` shows up in a new place. https://github.com/Instagram/Fixit/issues/195
## Test Plan
`pyre --preserve-path check`
