### PR TITLE
Inheritable configs

### DIFF
--- a/fixit/common/base.py
+++ b/fixit/common/base.py
@@ -57,7 +57,7 @@ class LintConfig:
     packages: List[str] = field(default_factory=lambda: DEFAULT_PACKAGES)
     repo_root: str = "."
     rule_config: Dict[str, Dict[str, object]] = field(default_factory=dict)
-    inherit: bool = True
+    inherit: bool = False
 
 
 class BaseContext:

--- a/fixit/common/base.py
+++ b/fixit/common/base.py
@@ -57,6 +57,7 @@ class LintConfig:
     packages: List[str] = field(default_factory=lambda: DEFAULT_PACKAGES)
     repo_root: str = "."
     rule_config: Dict[str, Dict[str, object]] = field(default_factory=dict)
+    inherit: bool = True
 
 
 class BaseContext:

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -93,6 +93,7 @@ def get_validated_settings(
         file_content[path_setting_name] = str(abspath)
 
     file_content["inherit"] = file_content.get("inherit", False)
+    file_content["allow_list_rules"] = file_content.get("allow_list_rules", [])
     return file_content
 
 
@@ -182,7 +183,7 @@ def get_rules_from_config() -> LintRuleCollectionT:
             lint_config.block_list_rules,
             all_names,
             lint_config.allow_list_rules,
-            seen_modules
+            seen_modules,
         )
         rules.update(rules_from_pkg)
     return rules

--- a/fixit/common/config.schema.json
+++ b/fixit/common/config.schema.json
@@ -9,7 +9,8 @@
             "type": "array",
             "items": {
                 "type": "string"
-            }
+            },
+            "mergeStrategy": "append"
         },
         "block_list_patterns": {
             "description": "A list of patterns that indicate that a file should not be linted.",

--- a/fixit/common/config.schema.json
+++ b/fixit/common/config.schema.json
@@ -9,14 +9,16 @@
             "type": "array",
             "items": {
                 "type": "string"
-            }
+            },
+            "mergeStrategy": "append"
         },
         "block_list_rules": {
             "description": "A list of rules (whether custom or from Fixit) that should not be applied to the repository.",
             "type": "array",
             "items": {
                 "type": "string"
-            }
+            },
+            "mergeStrategy": "append"
         },
         "fixture_dir": {
             "description": "The directory in which fixture files required for unit testing are to be found.",
@@ -31,14 +33,16 @@
             "type": "array",
             "items": {
                 "type": "string"
-            }
+            },
+            "mergeStrategy": "append"
         },
         "packages": {
             "description": "The Python packages in which to search for lint rules.",
             "type": "array",
             "items": {
                 "type": "string"
-            }
+            },
+            "mergeStrategy": "append"
         },
         "repo_root": {
             "description": "The path to the repository root.",
@@ -47,6 +51,10 @@
         "rule_config": {
             "description": "Rule-specific configurations.",
             "type": "object"
+        },
+        "inherit": {
+            "description": "Boolean to determine whether this config file will inherit properties from a parent config.",
+            "type": "boolean"
         }
     }
 }

--- a/fixit/common/config.schema.json
+++ b/fixit/common/config.schema.json
@@ -30,11 +30,13 @@
         },
         "fixture_dir": {
             "description": "The directory in which fixture files required for unit testing are to be found.",
-            "type": "string"
+            "type": "string",
+            "mergeStrategy": "overwrite"
         },
         "use_noqa": {
             "description": "Defaults to False. Use True to support Flake8 lint suppression comment: noqa.",
-            "type": "boolean"
+            "type": "boolean",
+            "mergeStrategy": "overwrite"
         },
         "formatter": {
             "description": "A list of the formatter commands to use after a lint is complete.",
@@ -54,15 +56,18 @@
         },
         "repo_root": {
             "description": "The path to the repository root.",
-            "type": "string"
+            "type": "string",
+            "mergeStrategy": "overwrite"
         },
         "rule_config": {
             "description": "Rule-specific configurations.",
-            "type": "object"
+            "type": "object",
+            "mergeStrategy": "objectMerge"
         },
         "inherit": {
             "description": "Boolean to determine whether this config file will inherit properties from a parent config.",
-            "type": "boolean"
+            "type": "boolean",
+            "mergeStrategy": "overwrite"
         }
     }
 }

--- a/fixit/common/tests/.fixit.config.yaml
+++ b/fixit/common/tests/.fixit.config.yaml
@@ -1,3 +1,4 @@
 packages:
 - fixit.common.tests.dummy_package
 repo_root: .
+inherit: False

--- a/fixit/common/tests/.fixit.config.yaml
+++ b/fixit/common/tests/.fixit.config.yaml
@@ -2,3 +2,6 @@ packages:
 - fixit.common.tests.dummy_package
 repo_root: .
 inherit: False
+allow_list_rules:
+- DummyRule1
+- DummyRule2

--- a/fixit/common/tests/dummy_package/.fixit.config.yaml
+++ b/fixit/common/tests/dummy_package/.fixit.config.yaml
@@ -1,8 +1,9 @@
 block_list_rules:
-- DummyRule4
+- BlockedDummyRule1
 packages:
 - fixit.common.tests.dummy_package.dummy_subpackage
 repo_root: .
-block_list_rules:
-- BlockedDummyRule1
 inherit: True
+allow_list_rules:
+- DummyRule3
+- BlockedDummyRule2

--- a/fixit/common/tests/dummy_package/.fixit.config.yaml
+++ b/fixit/common/tests/dummy_package/.fixit.config.yaml
@@ -3,3 +3,6 @@ block_list_rules:
 packages:
 - fixit.common.tests.dummy_package.dummy_subpackage
 repo_root: .
+block_list_rules:
+- BlockedDummyRule1
+inherit: True

--- a/fixit/common/tests/dummy_package/dummy_subpackage/.fixit.config.yaml
+++ b/fixit/common/tests/dummy_package/dummy_subpackage/.fixit.config.yaml
@@ -1,0 +1,4 @@
+repo_root: .
+block_list_rules:
+- BlockedDummyRule2
+inherit: True

--- a/fixit/common/tests/dummy_package/dummy_subpackage/dummy.py
+++ b/fixit/common/tests/dummy_package/dummy_subpackage/dummy.py
@@ -7,15 +7,10 @@ from fixit.common.base import CstLintRule
 
 
 # Dummy rules for integration testing purposes.
-class DummyRule1(CstLintRule):
-    pass
-
-
-class DummyRule2(CstLintRule):
-    pass
-
-
 class DummyRule3(CstLintRule):
+    pass
+
+class BlockedDummyRule2(CstLintRule):
     pass
 
 

--- a/fixit/common/tests/dummy_package/dummy_subpackage/dummy.py
+++ b/fixit/common/tests/dummy_package/dummy_subpackage/dummy.py
@@ -10,6 +10,7 @@ from fixit.common.base import CstLintRule
 class DummyRule3(CstLintRule):
     pass
 
+
 class BlockedDummyRule2(CstLintRule):
     pass
 

--- a/fixit/common/tests/duplicate_dummy/.fixit.config.yaml
+++ b/fixit/common/tests/duplicate_dummy/.fixit.config.yaml
@@ -1,0 +1,4 @@
+repo_root: .
+packages:
+- fixit.common.tests.duplicate_dummy
+inherit: False

--- a/fixit/common/tests/duplicate_dummy/.fixit.config.yaml
+++ b/fixit/common/tests/duplicate_dummy/.fixit.config.yaml
@@ -1,4 +1,4 @@
 repo_root: .
 packages:
-- fixit.common.tests.duplicate_dummy
+- fixit.common.tests
 inherit: False

--- a/fixit/common/tests/duplicate_dummy/__init__.py
+++ b/fixit/common/tests/duplicate_dummy/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/fixit/common/tests/duplicate_dummy/duplicate_dummy.py
+++ b/fixit/common/tests/duplicate_dummy/duplicate_dummy.py
@@ -6,10 +6,6 @@
 from fixit.common.base import CstLintRule
 
 
-# Dummy rule for integration testing purposes.
+# Dummy rules for integration testing purposes.
 class DummyRule1(CstLintRule):
-    pass
-
-
-class BlockedDummyRule1(CstLintRule):
     pass

--- a/fixit/common/tests/duplicate_dummy/subduplicate_dummy/__init__.py
+++ b/fixit/common/tests/duplicate_dummy/subduplicate_dummy/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/fixit/common/tests/duplicate_dummy/subduplicate_dummy/duplicate_dummy1.py
+++ b/fixit/common/tests/duplicate_dummy/subduplicate_dummy/duplicate_dummy1.py
@@ -7,5 +7,5 @@ from fixit.common.base import CstLintRule
 
 
 # Dummy rules for integration testing purposes.
-class DummyRule1(CstLintRule):
+class DummyRule2(CstLintRule):
     pass

--- a/fixit/common/tests/duplicate_dummy/subduplicate_dummy/duplicate_dummy1.py
+++ b/fixit/common/tests/duplicate_dummy/subduplicate_dummy/duplicate_dummy1.py
@@ -6,10 +6,6 @@
 from fixit.common.base import CstLintRule
 
 
-# Dummy rule for integration testing purposes.
+# Dummy rules for integration testing purposes.
 class DummyRule1(CstLintRule):
-    pass
-
-
-class BlockedDummyRule1(CstLintRule):
     pass

--- a/fixit/common/tests/test_config.py
+++ b/fixit/common/tests/test_config.py
@@ -3,22 +3,28 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+
+from functools import wraps
+import json
 import os
 from pathlib import Path
+from typing import Dict, List, Union, Callable, TypeVar, Sequence, Any, Mapping
+from unittest import mock
+import tempfile
 
 from jsonschema.exceptions import ValidationError
 from libcst.testing.utils import UnitTest
 
-from fixit.common.config import get_validated_settings
+from fixit.common.config import _merge_lint_configs, get_validated_settings
 
+ReturnType = TypeVar("ReturnType")
 
-TEST_CONFIG = {
+TEST_CONFIG: Dict[str, Union[Dict[str, Dict[str, List[str]]], List[str], bool, str]] = {
     "formatter": ["black", "-", "--no-diff"],
     "packages": ["python.fixit.rules"],
     "block_list_rules": ["Flake8PseudoLintRule"],
     "fixture_dir": f"{os.getcwd()}",
     "repo_root": f"{os.getcwd()}",
-    "use_noqa": False,
     "rule_config": {
         "UnusedImportsRule": {
             "ignored_unused_modules": [
@@ -29,10 +35,29 @@ TEST_CONFIG = {
             ]
         },
     },
+    "inherit": False,
 }
 
 
+def with_temp_dir(func: Callable[..., ReturnType]) -> Callable[..., ReturnType]:
+    @wraps(func)
+    def wrapper(*args: Sequence[Any], **kwargs: Mapping[Any, Any]) -> ReturnType:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(f"{temp_dir}/.fixit.config.yaml").write_text(json.dumps(TEST_CONFIG))
+            Path(f"{temp_dir}/__init__").touch()
+            sub_dir = Path(f"{temp_dir}/subdir")
+            sub_dir.mkdir()
+            (sub_dir / "__init__").touch()
+            return func(*args, Path(temp_dir), sub_dir, **kwargs)
+
+    return wrapper
+
 class TestConfig(UnitTest):
+    def setUp(self):
+        patcher = mock.patch("fixit.common.config.Path.cwd")
+        self.mock_cwd = patcher.start()
+        self.addCleanup(self.mock_cwd.stop)
+
     def test_validated_settings_with_bad_types(self) -> None:
         bad_config = {"block_list_rules": False}
         with self.assertRaisesRegex(ValidationError, "False is not of type 'array'"):
@@ -42,19 +67,39 @@ class TestConfig(UnitTest):
         config = {"block_list_rules": ["FakeRule"]}
         settings = get_validated_settings(config, Path("."))
         self.assertEqual(
-            {"block_list_rules": ["FakeRule"], "fixture_dir": ".", "repo_root": "."},
+            {
+                "block_list_rules": ["FakeRule"],
+                "fixture_dir": ".",
+                "repo_root": ".",
+                "inherit": False,
+            },
             settings,
         )
 
     def test_validated_settings_all_keys(self) -> None:
-        self.maxDiff = None
-        config = {
-            "formatter": ["black", "-", "--no-diff"],
-            "packages": ["python.fixit.rules"],
-            "block_list_rules": ["Flake8PseudoLintRule"],
-            "fixture_dir": f"{os.getcwd()}",
-            "repo_root": f"{os.getcwd()}",
-            "rule_config": {
+        settings = get_validated_settings(TEST_CONFIG, Path("."))
+        self.assertEqual(
+            TEST_CONFIG,
+            settings,
+        )
+
+    @with_temp_dir
+    def test_merge_lint_configs_simple(self, temp_dir: Path, sub_dir: Path) -> None:
+        self.mock_cwd.return_value = sub_dir
+        test_config_2 = {
+            "block_list_rules": ["BlockedRule"],
+            "formatter": ["fakeformatter"],
+            "use_noqa": True,
+            "inherit": True,
+        }
+        (sub_dir / ".fixit.config.yaml").write_text(json.dumps(test_config_2))
+        expected_merged_config = {
+            "formatter": ["black", "-", "--no-diff", "fakeformatter"],  # appended
+            "packages": ["python.fixit.rules"],  # inherited
+            "block_list_rules": ["Flake8PseudoLintRule", "BlockedRule"],  # appended
+            "fixture_dir": f"{sub_dir}",  # inherited
+            "repo_root": f"{sub_dir}",  # inherited
+            "rule_config": {  # inherited
                 "UnusedImportsRule": {
                     "ignored_unused_modules": [
                         "__future__",
@@ -64,9 +109,103 @@ class TestConfig(UnitTest):
                     ]
                 },
             },
+            "use_noqa": True,  # overridden
+            "inherit": True,  # overridden
         }
-        settings = get_validated_settings(config, Path("."))
+        merged_config = _merge_lint_configs()
+        self.assertEqual(expected_merged_config, merged_config)
+
+    @with_temp_dir
+    def test_merge_lint_configs_rule_config_new_rule(
+        self, temp_dir: Path, sub_dir: Path
+    ) -> None:
+        self.mock_cwd.return_value = sub_dir
+        test_config_2 = {
+            "rule_config": {"TestingRule": {"a_config_setting": True}},
+            "inherit": True,
+        }
+        (sub_dir / ".fixit.config.yaml").write_text(json.dumps(test_config_2))
+        expected_merged_config = {
+            "formatter": ["black", "-", "--no-diff"],
+            "packages": ["python.fixit.rules"],
+            "block_list_rules": ["Flake8PseudoLintRule"],
+            "fixture_dir": f"{sub_dir}",
+            "repo_root": f"{sub_dir}",
+            "rule_config": {
+                "UnusedImportsRule": {
+                    "ignored_unused_modules": [
+                        "__future__",
+                        "__static__",
+                        "__static__.compiler_flags",
+                        "__strict__",
+                    ]
+                },
+                "TestingRule": {"a_config_setting": True},
+            },
+            "inherit": True,
+        }
+        merged_config = _merge_lint_configs()
+        self.assertEqual(expected_merged_config, merged_config)
+
+    @with_temp_dir
+    def test_merge_lint_configs_rule_config_override_rule(
+        self, temp_dir: Path, sub_dir: Path
+    ) -> None:
+        self.mock_cwd.return_value = sub_dir
+        test_config_2 = {
+            "rule_config": {
+                "UnusedImportsRule": {"ignored_unused_modules": ["__init__"]}
+            },
+            "inherit": True,
+        }
+        (sub_dir / ".fixit.config.yaml").write_text(json.dumps(test_config_2))
+        expected_merged_config = {
+            "formatter": ["black", "-", "--no-diff"],
+            "packages": ["python.fixit.rules"],
+            "block_list_rules": ["Flake8PseudoLintRule"],
+            "fixture_dir": f"{sub_dir}",
+            "repo_root": f"{sub_dir}",
+            "rule_config": {
+                "UnusedImportsRule": {"ignored_unused_modules": ["__init__"]}
+            },
+            "inherit": True,
+        }
+        merged_config = _merge_lint_configs()
+        self.assertEqual(expected_merged_config, merged_config)
+
+    @with_temp_dir
+    @mock.patch("fixit.common.config._get_config_schema")
+    def test_merge_lint_configs_missing_schema(
+        self, temp_dir: Path, sub_dir: Path, mock_schema: mock.Mock
+    ) -> None:
+        self.mock_cwd.return_value = sub_dir
+        mock_schema.return_value = None
+        test_config_2 = {"block_list_rules": ["NotMerged"], "inherit": True}
+        (sub_dir / ".fixit.config.yaml").write_text(json.dumps(test_config_2))
+        merged_config = _merge_lint_configs()
+        # Returns the first LintConfig found (the lowest leaf)
         self.assertEqual(
-            config,
-            settings,
+            merged_config["block_list_rules"], ["NotMerged"]
         )
+        self.assertEqual(
+            merged_config["inherit"], True
+        )
+
+    @with_temp_dir
+    def test_merge_lint_configs_inherit_false(
+        self, temp_dir: Path, sub_dir: Path
+    ) -> None:
+        self.mock_cwd.return_value = sub_dir
+        test_config_2 = {"block_list_rules": ["NotMerged"], "inherit": False}
+        (sub_dir / ".fixit.config.yaml").write_text(json.dumps(test_config_2))
+        merged_config = _merge_lint_configs()
+        # Returns the first LintConfig found (the lowest leaf)
+        self.assertEqual(
+            merged_config["block_list_rules"], ["NotMerged"]
+        )
+        self.assertEqual(
+            merged_config["inherit"], False
+        )
+
+    def test_inherit_empty_alow_list_rules(self) -> None:
+        pass

--- a/fixit/common/tests/test_config.py
+++ b/fixit/common/tests/test_config.py
@@ -60,7 +60,7 @@ class TestConfig(UnitTest):
     def setUp(self) -> None:
         patcher = mock.patch("fixit.common.config.Path.cwd")
         self.mock_cwd = patcher.start()
-        self.addCleanup(self.mock_cwd.stop)
+        self.addCleanup(patcher.stop)
 
     def test_validated_settings_with_bad_types(self) -> None:
         bad_config = {"block_list_rules": False}

--- a/fixit/common/tests/test_imports.py
+++ b/fixit/common/tests/test_imports.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 from libcst.testing.utils import UnitTest
 
-from fixit.common.config import get_lint_config, get_rules_from_config
+from fixit.common.config import (
+    _merge_lint_configs,
+    get_lint_config,
+    get_rules_from_config,
+)
 from fixit.common.utils import (
     DuplicateLintRuleNameError,
     LintRuleNotFoundError,
@@ -22,13 +26,20 @@ from fixit.common.utils import (
 DUMMY_PACKAGE: str = "fixit.common.tests.dummy_package"
 DUMMY_SUBPACKAGE: str = "fixit.common.tests.dummy_package.dummy_subpackage"
 DUMMY_CONFIG_PATH: str = ".fixit.config.yaml"
+DUMMY_SUBPACKAGE_PATH: Path = (
+    Path(__file__).parent / "dummy_package" / "dummy_subpackage"
+)
+DUPLICATE_DUMMY: str = "fixit.common.tests.duplicate_dummy"
+DUPLICATE_DUMMY_PATH: Path = (
+    Path(__file__).parent / "duplicate_dummy"
+)
 
 # Using dummy config file, test whether the rule import helpers work as expected.
 class ImportsTest(UnitTest):
     def setUp(self) -> None:
         # We need to change the working directory so that the dummy config file is used.
         self.old_wd = os.getcwd()
-        test_dir = Path(__file__).parent
+        test_dir = DUMMY_SUBPACKAGE_PATH
         os.chdir(test_dir)
 
         # We also need to clear the lru_cache for the get_lint_config function between tests.
@@ -40,23 +51,26 @@ class ImportsTest(UnitTest):
         getattr(get_lint_config, "cache_clear")()
 
     def test_get_rules_from_config(self) -> None:
-        with self.assertRaises(DuplicateLintRuleNameError):
-            # We have two dummy lint rules with the same name. Verify this raises an error.
-            get_rules_from_config()
-
-        # Now try to import all rules from a package where there aren't any duplicates.
-        getattr(get_lint_config, "cache_clear")()
-        next_dir = os.path.join(os.getcwd(), "dummy_package")
-        os.chdir(next_dir)
         rules = get_rules_from_config()
 
         # Assert all rules are imported as expected.
         self.assertEqual(len(rules), 3)
-        self.assertTrue(all(r.__module__ == f"{DUMMY_SUBPACKAGE}.dummy" for r in rules))
+        expected_rules = {
+            f"{DUMMY_SUBPACKAGE}.dummy",
+            f"{DUMMY_PACKAGE}.dummy_1",
+            f"{DUMMY_PACKAGE}.dummy_2",
+        }
+        self.assertEqual(expected_rules, {r.__module__ for r in rules})
+
+    def test_get_rules_from_config_duplicate(self) -> None:
+        os.chdir(DUPLICATE_DUMMY_PATH)
+        with self.assertRaisesRegex(DuplicateLintRuleNameError, "Lint rule name DummyRule1 is duplicated\."):
+            # We have two dummy lint rules with the same name. Verify this raises an error.
+            get_rules_from_config()
 
     def test_import_rule_from_package(self) -> None:
         rules_package = get_lint_config().packages
-        self.assertEqual(rules_package, [DUMMY_PACKAGE])
+        self.assertEqual(rules_package, [DUMMY_PACKAGE, DUMMY_SUBPACKAGE])
 
         # Test with an existing dummy rule.
         imported_rule = import_rule_from_package(rules_package[0], "DummyRule2")
@@ -77,6 +91,21 @@ class ImportsTest(UnitTest):
 
         with self.assertRaises(LintRuleNotFoundError):
             imported_rule = find_and_import_rule("DummyRule1000", rules_packages)
+
+    def test_merge_lint_configs(self) -> None:
+        merged_config = _merge_lint_configs()
+        expected_config = {
+            "fixture_dir": f"{os.getcwd()}",
+            "repo_root": f"{os.getcwd()}",
+            "block_list_rules": ["BlockedDummyRule1", "BlockedDummyRule2"],
+            "inherit": True,
+            "packages": [
+                "fixit.common.tests.dummy_package",
+                "fixit.common.tests.dummy_package.dummy_subpackage",
+            ],
+        }
+        self.assertEqual(expected_config, merged_config)
+
 
 
 class AllowListTest(UnitTest):

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -106,6 +106,7 @@ def import_distinct_rules_from_package(
     block_list_rules: List[str] = [],
     seen_names: Optional[Set[str]] = None,
     allow_list_rules: Optional[List[str]] = None,
+    seen_modules: Optional[Set[str]] = None,
 ) -> LintRuleCollectionT:
     # Import all rules from the specified package, omitting rules that appear in the block list.
     # Raises error on repeated rule names.
@@ -113,7 +114,13 @@ def import_distinct_rules_from_package(
     rules: LintRuleCollectionT = set()
     if seen_names is None:
         seen_names: Set[str] = set()
-    for _module_name, module in import_submodules(package).items():
+    if seen_modules is None:
+        seen_modules: Set[str] = set()
+    for module_name, module in import_submodules(package).items():
+        # Filter out overlapping packages
+        if module_name in seen_modules:
+            continue
+        seen_modules.add(module_name)
         for name in dir(module):
             try:
                 obj = getattr(module, name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ flake8>=3.8.1
 libcst>=0.3.18
 pyyaml>=5.2
 jsonschema>=3.2.0
+jsonmerge>=1.8.0
 importlib-resources>=5.1.2


### PR DESCRIPTION
## Summary
Putting up a draft to start discussion. This implements what was posted in #183. Configs are inheritable via simple hierarchy. There is nothing fancy like custom schema definitions or partial inheritance. A config will be inheritable if they add the key `inherit = True`, it defaults to `False` if the key is not set. 

Different keys are inherited differently, see `fixit/common/config.schema.json` for a breakdown and [jsonmerge](https://github.com/avian2/jsonmerge) for more details.

`allow_list_rules` is kind of a funny one, since if it is not included it defaults to all rules being allowed. If a leaf node inherits an empty `allow_list_rules` but the leaf config defines rules in the list, it has the effect of turning off all the rules that are not listed. 

`rule_config`s currently use jsonmerge's `objectMerge` with the defaults set. This means if there are two identical keys with different values, the value of the leaf config _overwrites_ the value of the root. If keys are not identical, they are both included in the final result. For example:

`root.fixit.config.yaml`
```
"rule_config": {
    "UnusedImportsRule": {
        "ignored_unused_modules": [
            "__future__",
            "__static__",
            "__static__.compiler_flags",
            "__strict__",
        ]
    },
   "Other Rule": { "yes": True}
}
```
`leaf.fixit.config.yaml`
```
"rule_config": {
   "UnusedImportsRule": {
        "ignored_unused_modules": ["__init__"]
  },
  "CoolRule": {"was": "sup"}
}
```
Results in:
```
"rule_config": {
   "UnusedImportsRule": {
        "ignored_unused_modules": ["__init__"]
  },
  "Other Rule": { "yes": True},
  "CoolRule": {"was": "sup"}
```

As expressed in the discussion post, I think this is most often the state that we want. But rules are variable, and I can forsee cases where someone would want this different (merging of lists instead of overwriting, for example, or completely overwriting). This seems like a good starting point for today.

## Test Plan
Added unit tests
