### PR TITLE
Use skip ignore comment instead of use ignore comment in run_rules

### DIFF
--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -32,7 +32,7 @@ from fixit.cli.args import (
     get_paths_parser,
     get_rules_parser,
     get_skip_ignore_byte_marker_parser,
-    get_use_ignore_comments_parser,
+    get_skip_ignore_comments_parser,
 )
 from fixit.cli.formatter import LintRuleReportFormatter
 from fixit.cli.full_repo_metadata import (
@@ -55,8 +55,8 @@ runs all lint rules found in the packages specified in `fixit.config.yaml`."""
 PARENTS: List[argparse.ArgumentParser] = [
     get_paths_parser(),
     get_rules_parser(),
-    get_use_ignore_comments_parser(),
     get_skip_ignore_byte_marker_parser(),
+    get_skip_ignore_comments_parser(),
     get_compact_parser(),
     get_multiprocessing_parser(),
     get_metadata_cache_parser(),


### PR DESCRIPTION
## Summary
Currently, the `run_rules` command does **not** provide a way for us to ignore ignore comments.  The default for the command is to respect them and the override flag provided just does the same.  This PR replaces the option with the proper one that means that we are able to opt out if the `--skip-ignore-comments` is provided.

## Test Plan
Setting up the test.  Currently, there is a file in the repository that is missing a header file:
```
$ python -m fixit.cli.run_rules --rules AddMissingHeaderRule
Scanning 99 files
Testing 1 rules

/Users/markv/src/Fixit/.github/scripts/tox_job.py:1:1
    AddMissingHeaderRule: A required header comment for this file is missing.

Found 1 reports in 99 files in 4.57 seconds.
```

Let's add a suppression comment:
```
diff --git a/.github/scripts/tox_job.py b/.github/scripts/tox_job.py
index 9b5aac0..b01c678 100644
--- a/.github/scripts/tox_job.py
+++ b/.github/scripts/tox_job.py
@@ -1,3 +1,4 @@
+# lint-ignore: AddMissingHeaderRule
 """
 Generate the appropriate tox job name to match the current
 version of python available. For use with Github Actions
```

Now, let's run the lint again:
```
$  python -m fixit.cli.run_rules --rules AddMissingHeaderRule
Scanning 99 files
Testing 1 rules


Found 0 reports in 99 files in 4.55 seconds.
```

There are 0 reports, as expected.  Now, let's check to see if the `--skip-ignore-comments` flag works:
```
$ python -m fixit.cli.run_rules --rules AddMissingHeaderRule --skip-ignore-comments
Scanning 99 files
Testing 1 rules

/Users/markv/src/Fixit/.github/scripts/tox_job.py:1:1
    AddMissingHeaderRule: A required header comment for this file is missing.

Found 1 reports in 99 files in 2.59 seconds.
```

It does!  Previously, there would no way to suppress the ignore comment.  Help provided the following:
```
$ python -m fixit.cli.run_rules --rules AddMissingHeaderRule --help
.
.
.
  --use-ignore-comments
                        Obey `# noqa`, `# lint-fixme` and `# lint-ignore`
                        comments.
.
.
.
```

However, running the command without anything shows that we are respecting ignore comments:
```
$  python -m fixit.cli.run_rules --rules AddMissingHeaderRule
Scanning 99 files
Testing 1 rules


Found 0 reports in 99 files in 4.95 seconds.
```

Providing the `--use-ignore-comments` doesn't make sense because we want to ignore/skip them, but let's try anyways:
```
$  python -m fixit.cli.run_rules --rules AddMissingHeaderRule --use-ignore-comments
Scanning 99 files
Testing 1 rules


Found 0 reports in 99 files in 5.03 seconds.
```


