### PR TITLE
Add dict comprehension to gather_sequential_await.py

### DIFF
--- a/fixit/rules/gather_sequential_await.py
+++ b/fixit/rules/gather_sequential_await.py
@@ -59,6 +59,13 @@ class GatherSequentialAwaitRule(CstLintRule):
             """,
             line=2,
         ),
+        Invalid(
+            """
+            async def async_check_dict_comprehension():
+                {_i: await async_foo() for _i in range(0, 2)}
+            """,
+            line=2,
+        ),
     ]
 
     def should_skip_file(self) -> bool:
@@ -77,4 +84,7 @@ class GatherSequentialAwaitRule(CstLintRule):
             isinstance(parent, (cst.ListComp, cst.SetComp, cst.GeneratorExp))
             and parent.elt is node
         ):
+            self.report(node)
+
+        if isinstance(parent, cst.DictComp) and parent.value is node:
             self.report(node)

--- a/fixit/rules/gather_sequential_await.py
+++ b/fixit/rules/gather_sequential_await.py
@@ -61,8 +61,15 @@ class GatherSequentialAwaitRule(CstLintRule):
         ),
         Invalid(
             """
-            async def async_check_dict_comprehension():
+            async def async_check_dict_comprehension_value():
                 {_i: await async_foo() for _i in range(0, 2)}
+            """,
+            line=2,
+        ),
+        Invalid(
+            """
+            async def async_check_dict_comprehension_key():
+                {await async_foo(_i): _i for _i in range(0, 2)}
             """,
             line=2,
         ),
@@ -86,5 +93,7 @@ class GatherSequentialAwaitRule(CstLintRule):
         ):
             self.report(node)
 
-        if isinstance(parent, cst.DictComp) and parent.value is node:
+        if isinstance(parent, cst.DictComp) and (
+            parent.value is node or parent.key is node
+        ):
             self.report(node)


### PR DESCRIPTION
## Summary

Calling an await within a dictionary comprehension runs it sequentially. Instead, this should typically be done using a gather call (i.e. gather_dict) to ensure that these will run in parallel. This checks that dict comprehensions also throw a Lint error.

## Test Plan

Added a unit test case and verified that all tests pass for this rule.
