### PR TITLE
Fix this usage: python3 -m fixit.cli.run_rules <path>

### DIFF
--- a/fixit/cli/args.py
+++ b/fixit/cli/args.py
@@ -112,7 +112,9 @@ def get_rules_parser() -> argparse.ArgumentParser:
 def relative_to_repo_root(_path: str) -> Path:
     repo_root = get_lint_config().repo_root
     try:
-        return Path(_path).resolve(strict=True).relative_to(repo_root)
+        path = Path(_path).resolve(strict=True)
+        path.relative_to(repo_root)
+        return path
     except ValueError:
         raise argparse.ArgumentTypeError(
             f"Invalid value {_path}.\n"

--- a/fixit/cli/args.py
+++ b/fixit/cli/args.py
@@ -109,7 +109,7 @@ def get_rules_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def relative_to_repo_root(_path: str) -> Path:
+def enforce_relative_to_repo_root(_path: str) -> Path:
     repo_root = get_lint_config().repo_root
     try:
         path = Path(_path).resolve(strict=True)
@@ -128,7 +128,7 @@ def get_paths_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "paths",
         nargs="*",
-        type=relative_to_repo_root,
+        type=enforce_relative_to_repo_root,
         default=(Path(get_lint_config().repo_root),),
         help=(
             "The name of a directory (e.g. media) or file (e.g. media/views.py) "


### PR DESCRIPTION
## Summary
Using a relative path here doesn't always work.

Consider this scenario:
 -  <path> is specified
 - it is relative to repo_root
 - but repo_root != cwd

In that case `fixit.cli.find_files` will locate zero files.

## Test Plan


