### PR TITLE
Gate importlib-resources to python_version < '3.7'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ flake8>=3.8.1
 libcst>=0.3.18
 pyyaml>=5.2
 jsonschema>=3.2.0
-importlib-resources>=5.1.2
+importlib-resources>=5.1.2; python_version < '3.7'


### PR DESCRIPTION
## Summary
`importlib.resources` is built into Python 3.7 and above;
gate the requirements on the backported PyPI package to
Python < 3.7.

Signed-off-by: Michel Salim <michel@fb.com>

## Test Plan
Tested by building in Fedora, and verifying that `importlib-resources` does not show up as a requirement (Fedora Rawhide has Python 3.10)

```
$ rpm -qp --requires /var/lib/mock/fedora-rawhide-x86_64-fixit/result/python3-fixit-0.1.4-3.fc36.noarch.rpm 
/usr/bin/python3
python(abi) = 3.10
python3.10dist(flake8) >= 3.8.1
python3.10dist(jsonschema) >= 3.2
python3.10dist(libcst) >= 0.3.18
python3.10dist(pyyaml) >= 5.2
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PartialHardlinkSets) <= 4.0.4-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
```