### PR TITLE
Drop use of libcst.testing.*

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -6,6 +6,7 @@
         ".*/\\.tox/.*"
     ],
     "search_path": [
+        "stubs",
         {"site-package": "libcst"},
         {"site-package": "importlib_resources"},
         {"site-package": "flake8"}

--- a/fixit/cli/tests/test_args.py
+++ b/fixit/cli/tests/test_args.py
@@ -2,8 +2,9 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import unittest
+
 from libcst.codemod.commands.noop import NOOPCommand
-from libcst.testing.utils import UnitTest
 
 from fixit.cli.args import get_rule_parser
 
@@ -12,7 +13,7 @@ class SomeFakeRule:
     pass
 
 
-class LintRuleCLIArgsTest(UnitTest):
+class LintRuleCLIArgsTest(unittest.TestCase):
     def test_rule_parser(self) -> None:
         parser = get_rule_parser().parse_args(
             ["fixit.cli.tests.test_args.SomeFakeRule"]

--- a/fixit/cli/tests/test_formatter.py
+++ b/fixit/cli/tests/test_formatter.py
@@ -2,10 +2,10 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import unittest
 from pathlib import Path
 
 import libcst as cst
-from libcst.testing.utils import UnitTest
 
 from fixit.cli.formatter import format_warning, LintRuleReportFormatter
 from fixit.common.report import BaseLintRuleReport, CstLintRuleReport
@@ -19,7 +19,7 @@ class _ExtendedLintRuleReportFormatter(LintRuleReportFormatter):
         return "<overridden details_raw>"
 
 
-class LintRuleReportFormatterTest(UnitTest):
+class LintRuleReportFormatterTest(unittest.TestCase):
     def setUp(self) -> None:
         self.fake_filepath = Path("fake/path.py")
         self.report = CstLintRuleReport(
@@ -73,7 +73,7 @@ class LintRuleReportFormatterTest(UnitTest):
         )
 
 
-class FormatWarningTest(UnitTest):
+class FormatWarningTest(unittest.TestCase):
     def test_format_warning(self) -> None:
         self.assertEqual(
             format_warning("Some long warning message that should be wrapped.", 20),

--- a/fixit/cli/tests/test_ipc.py
+++ b/fixit/cli/tests/test_ipc.py
@@ -8,9 +8,8 @@ import io
 import json
 import os
 import tempfile
+import unittest
 from typing import Any, Dict
-
-from libcst.testing.utils import UnitTest
 
 from fixit.cli import run_ipc
 from fixit.cli.args import LintWorkers
@@ -25,7 +24,7 @@ EXPECTED_FAILURE_REPORT: Dict[str, Any] = json.loads(
 )
 
 
-class IpcTest(UnitTest):
+class IpcTest(unittest.TestCase):
     def setUp(self) -> None:
         self.opts = generate_mock_lint_opt()
 

--- a/fixit/cli/tests/test_lint_opts.py
+++ b/fixit/cli/tests/test_lint_opts.py
@@ -3,12 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast, Collection, List, Optional, Sequence
 
 from libcst import Module
-from libcst.testing.utils import UnitTest
 
 from fixit.cli import LintOpts, map_paths
 from fixit.cli.args import LintWorkers
@@ -87,7 +87,7 @@ def generate_mock_lint_opt(global_list: Optional[List[str]] = None) -> LintOpts:
     )
 
 
-class LintOptsTest(UnitTest):
+class LintOptsTest(unittest.TestCase):
     def setUp(self) -> None:
         self.global_list = []
         self.opts = generate_mock_lint_opt(global_list=self.global_list)

--- a/fixit/cli/tests/test_type_inference.py
+++ b/fixit/cli/tests/test_type_inference.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import subprocess
+import unittest
 from pathlib import Path
 from typing import Collection, Dict, Mapping, Optional, Set, Union
 from unittest.mock import MagicMock, patch
@@ -11,7 +12,6 @@ from unittest.mock import MagicMock, patch
 import libcst as cst
 from libcst.metadata import MetadataWrapper, TypeInferenceProvider
 from libcst.metadata.base_provider import ProviderT
-from libcst.testing.utils import UnitTest
 
 from fixit.cli import LintWorkers, map_paths
 from fixit.common.base import CstLintRule, LintConfig, LintRuleT
@@ -55,7 +55,7 @@ def map_paths_operation(
         return str(e)
 
 
-class TypeInferenceTest(UnitTest):
+class TypeInferenceTest(unittest.TestCase):
     DUMMY_PATH: Path = Path("fake/path.py")
     DUMMY_PATH_2: Path = Path("fake/path_2.py")
 

--- a/fixit/common/tests/test_autofix.py
+++ b/fixit/common/tests/test_autofix.py
@@ -3,71 +3,97 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
 from typing import Callable, Union
 
 import libcst as cst
 from libcst.metadata import CodePosition, MetadataWrapper
-from libcst.testing.utils import data_provider, UnitTest
+from parameterized import param, parameterized
 
 from fixit.common.autofix import LintPatch
 
 
-class AutofixTest(UnitTest):
-    @data_provider(
-        {
-            "full_module": {
-                "original_module": "# hello, world\ndef foo(): ...\nbar()\n",
-                "replacement_module": "val = 1 + 2\nraise Exception()\n",
-                "get_original_node": lambda module: module,
-                "get_replacement_node": lambda __: cst.parse_module(
-                    "val = 1 + 2\nraise Exception()\n"
-                ),
-            },
-            "full_module_noop": {
-                "original_module": "# hello, world\ndef foo(): ...\nbar()\n",
-                "replacement_module": "# hello, world\ndef foo(): ...\nbar()\n",
-                "get_original_node": lambda module: module,
-                "get_replacement_node": lambda module: module.deep_clone(),
-            },
-            "remove_statement": {
-                "original_module": "first_line\nsecond_line\n",
-                "replacement_module": "second_line\n",
-                "get_original_node": lambda module: module.body[0],
-                "get_replacement_node": lambda __: cst.RemovalSentinel.REMOVE,
-            },
-            "first_statement": {
-                "original_module": "a\nb\n",
-                "replacement_module": "new_statement()\nb\n",
-                "get_original_node": lambda module: module.body[0],
-                "get_replacement_node": lambda __: cst.parse_statement(
-                    "new_statement()"
-                ),
-            },
-            "first_expression": {
-                "original_module": "old_fn()\nb\n",
-                "replacement_module": "new_fn()\nb\n",
-                "get_original_node": lambda module: module.body[0].body[0].value.func,
-                "get_replacement_node": lambda __: cst.Name("new_fn"),
-            },
-            "last_statement": {
-                "original_module": "a\nb",
-                "replacement_module": "a\nnew_statement()",
-                "get_original_node": lambda module: module.body[1],
-                "get_replacement_node": lambda __: cst.parse_statement(
-                    "new_statement()\n"
-                ),
-            },
-            "last_expression": {
-                "original_module": "a\none + two",
-                "replacement_module": "a\none + new_value",
-                "get_original_node": lambda module: module.body[1].body[0].value.right,
-                "get_replacement_node": lambda __: cst.Name("new_value"),
-            },
-        }
+class AutofixTest(unittest.TestCase):
+    @parameterized.expand(
+        (
+            param(
+                "full_module",
+                **{
+                    "original_module": "# hello, world\ndef foo(): ...\nbar()\n",
+                    "replacement_module": "val = 1 + 2\nraise Exception()\n",
+                    "get_original_node": lambda module: module,
+                    "get_replacement_node": lambda __: cst.parse_module(
+                        "val = 1 + 2\nraise Exception()\n"
+                    ),
+                },
+            ),
+            param(
+                "full_module_noop",
+                **{
+                    "original_module": "# hello, world\ndef foo(): ...\nbar()\n",
+                    "replacement_module": "# hello, world\ndef foo(): ...\nbar()\n",
+                    "get_original_node": lambda module: module,
+                    "get_replacement_node": lambda module: module.deep_clone(),
+                },
+            ),
+            param(
+                "remove_statement",
+                **{
+                    "original_module": "first_line\nsecond_line\n",
+                    "replacement_module": "second_line\n",
+                    "get_original_node": lambda module: module.body[0],
+                    "get_replacement_node": lambda __: cst.RemovalSentinel.REMOVE,
+                },
+            ),
+            param(
+                "first_statement",
+                **{
+                    "original_module": "a\nb\n",
+                    "replacement_module": "new_statement()\nb\n",
+                    "get_original_node": lambda module: module.body[0],
+                    "get_replacement_node": lambda __: cst.parse_statement(
+                        "new_statement()"
+                    ),
+                },
+            ),
+            param(
+                "first_expression",
+                **{
+                    "original_module": "old_fn()\nb\n",
+                    "replacement_module": "new_fn()\nb\n",
+                    "get_original_node": lambda module: module.body[0]
+                    .body[0]
+                    .value.func,
+                    "get_replacement_node": lambda __: cst.Name("new_fn"),
+                },
+            ),
+            param(
+                "last_statement",
+                **{
+                    "original_module": "a\nb",
+                    "replacement_module": "a\nnew_statement()",
+                    "get_original_node": lambda module: module.body[1],
+                    "get_replacement_node": lambda __: cst.parse_statement(
+                        "new_statement()\n"
+                    ),
+                },
+            ),
+            param(
+                "last_expression",
+                **{
+                    "original_module": "a\none + two",
+                    "replacement_module": "a\none + new_value",
+                    "get_original_node": lambda module: module.body[1]
+                    .body[0]
+                    .value.right,
+                    "get_replacement_node": lambda __: cst.Name("new_value"),
+                },
+            ),
+        )
     )
     def test_get(
         self,
-        *,
+        _name: str,
         original_module: str,
         replacement_module: str,
         get_original_node: Callable[[cst.Module], cst.CSTNode],
@@ -83,55 +109,79 @@ class AutofixTest(UnitTest):
         self.assertEqual(patch.apply(original_module), replacement_module)
         self.assertEqual(patch.minimize().apply(original_module), replacement_module)
 
-    @data_provider(
-        {
-            "non_minimizable": {
-                "before": LintPatch(0, CodePosition(1, 0), "foobar", "barfoo"),
-                "after": LintPatch(0, CodePosition(1, 0), "foobar", "barfoo"),
-            },
-            "identical_tail": {
-                "before": LintPatch(
-                    0, CodePosition(1, 0), "hello, world!\n", "goodbye, world!\n"
-                ),
-                "after": LintPatch(0, CodePosition(1, 0), "hello", "goodbye"),
-            },
-            "identical_head": {
-                "before": LintPatch(0, CodePosition(1, 0), "who", "what"),
-                "after": LintPatch(2, CodePosition(1, 2), "o", "at"),
-            },
-            "newlines_lf": {
-                "before": LintPatch(0, CodePosition(1, 0), "a\nb", "a\nc"),
-                "after": LintPatch(2, CodePosition(2, 0), "b", "c"),
-            },
-            "newlines_cr": {
-                "before": LintPatch(0, CodePosition(1, 0), "a\rb", "a\rc"),
-                "after": LintPatch(2, CodePosition(2, 0), "b", "c"),
-            },
-            "newlines_crlf": {
-                "before": LintPatch(0, CodePosition(1, 0), "a\r\nb", "a\r\nc"),
-                "after": LintPatch(3, CodePosition(2, 0), "b", "c"),
-            },
-            "newlines_extended": {  # test a mix of multiple newlines in the same file
-                "before": LintPatch(
-                    0,
-                    CodePosition(1, 0),
-                    "a\r\nb\nc\rd\r\nis final",
-                    "a\r\nb\nc\rd\r\nis last",
-                ),
-                "after": LintPatch(13, CodePosition(5, 3), "final", "last"),
-            },
-            "minimizable_noop": {  # should minimize to an empty patch
-                "before": LintPatch(
-                    0,
-                    CodePosition(1, 0),
-                    "This is\nsome\ncode\n",
-                    "This is\nsome\ncode\n",
-                ),
-                "after": LintPatch(0, CodePosition(1, 0), "", ""),
-            },
-        }
+    @parameterized.expand(
+        (
+            param(
+                "non_minimizable",
+                **{
+                    "before": LintPatch(0, CodePosition(1, 0), "foobar", "barfoo"),
+                    "after": LintPatch(0, CodePosition(1, 0), "foobar", "barfoo"),
+                },
+            ),
+            param(
+                "identical_tail",
+                **{
+                    "before": LintPatch(
+                        0, CodePosition(1, 0), "hello, world!\n", "goodbye, world!\n"
+                    ),
+                    "after": LintPatch(0, CodePosition(1, 0), "hello", "goodbye"),
+                },
+            ),
+            param(
+                "identical_head",
+                **{
+                    "before": LintPatch(0, CodePosition(1, 0), "who", "what"),
+                    "after": LintPatch(2, CodePosition(1, 2), "o", "at"),
+                },
+            ),
+            param(
+                "newlines_lf",
+                **{
+                    "before": LintPatch(0, CodePosition(1, 0), "a\nb", "a\nc"),
+                    "after": LintPatch(2, CodePosition(2, 0), "b", "c"),
+                },
+            ),
+            param(
+                "newlines_cr",
+                **{
+                    "before": LintPatch(0, CodePosition(1, 0), "a\rb", "a\rc"),
+                    "after": LintPatch(2, CodePosition(2, 0), "b", "c"),
+                },
+            ),
+            param(
+                "newlines_crlf",
+                **{
+                    "before": LintPatch(0, CodePosition(1, 0), "a\r\nb", "a\r\nc"),
+                    "after": LintPatch(3, CodePosition(2, 0), "b", "c"),
+                },
+            ),
+            param(
+                "newlines_extended",
+                **{  # test a mix of multiple newlines in the same file
+                    "before": LintPatch(
+                        0,
+                        CodePosition(1, 0),
+                        "a\r\nb\nc\rd\r\nis final",
+                        "a\r\nb\nc\rd\r\nis last",
+                    ),
+                    "after": LintPatch(13, CodePosition(5, 3), "final", "last"),
+                },
+            ),
+            param(
+                "minimizable_noop",
+                **{  # should minimize to an empty patch
+                    "before": LintPatch(
+                        0,
+                        CodePosition(1, 0),
+                        "This is\nsome\ncode\n",
+                        "This is\nsome\ncode\n",
+                    ),
+                    "after": LintPatch(0, CodePosition(1, 0), "", ""),
+                },
+            ),
+        )
     )
-    def test_minimize(self, *, before: LintPatch, after: LintPatch) -> None:
+    def test_minimize(self, _name: str, before: LintPatch, after: LintPatch) -> None:
         self.assertEqual(before.minimize(), after)
         # this should be a noop
         self.assertEqual(after.minimize(), after)

--- a/fixit/common/tests/test_comments.py
+++ b/fixit/common/tests/test_comments.py
@@ -4,15 +4,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import tokenize
+import unittest
 from io import BytesIO
-
-from libcst.testing.utils import UnitTest
 
 from fixit.common.comments import CommentInfo
 from fixit.common.utils import dedent_with_lstrip
 
 
-class CommentInfoTest(UnitTest):
+class CommentInfoTest(unittest.TestCase):
     def test_comment_info(self) -> None:
         # A comment on a line with no other leading tokens is a "comment on own line".
         # In contrast, trailing comments come after other tokens on the same line.

--- a/fixit/common/tests/test_config.py
+++ b/fixit/common/tests/test_config.py
@@ -4,10 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import unittest
 from pathlib import Path
 
 from jsonschema.exceptions import ValidationError
-from libcst.testing.utils import UnitTest
 
 from fixit.common.config import get_validated_settings
 
@@ -32,7 +32,7 @@ TEST_CONFIG = {
 }
 
 
-class TestConfig(UnitTest):
+class TestConfig(unittest.TestCase):
     def test_validated_settings_with_bad_types(self) -> None:
         bad_config = {"block_list_rules": False}
         with self.assertRaisesRegex(ValidationError, "False is not of type 'array'"):

--- a/fixit/common/tests/test_flake8_compat.py
+++ b/fixit/common/tests/test_flake8_compat.py
@@ -3,9 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
 from pathlib import Path
-
-from libcst.testing.utils import UnitTest
 
 from fixit.common.base import LintConfig
 from fixit.common.pseudo_rule import PseudoContext
@@ -13,7 +12,7 @@ from fixit.rule_lint_engine import lint_file
 from fixit.rules.flake8_compat import Flake8PseudoLintRule
 
 
-class Flake8PseudoLintRuleTest(UnitTest):
+class Flake8PseudoLintRuleTest(unittest.TestCase):
     def test_lint_file(self) -> None:
         context = PseudoContext(
             file_path=Path("dummy/file/path.py"), source=b"undefined_fn()\n"

--- a/fixit/common/tests/test_full_repo_metadata.py
+++ b/fixit/common/tests/test_full_repo_metadata.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import unittest
 from collections import defaultdict
 from itertools import chain
 from pathlib import Path
@@ -13,12 +14,11 @@ from unittest.mock import call, MagicMock, patch
 
 from libcst.metadata import TypeInferenceProvider
 from libcst.metadata.base_provider import ProviderT
-from libcst.testing.utils import UnitTest
 
 from fixit.common.full_repo_metadata import FullRepoMetadataConfig, get_repo_caches
 
 
-class FullRepoMetadataTest(UnitTest):
+class FullRepoMetadataTest(unittest.TestCase):
     DUMMY_PATH = "fake/path.py"
 
     @patch("libcst.metadata.TypeInferenceProvider.gen_cache")

--- a/fixit/common/tests/test_get_code.py
+++ b/fixit/common/tests/test_get_code.py
@@ -3,12 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from libcst.testing.utils import UnitTest
+
+import unittest
 
 from fixit.common.base import _get_code
 
 
-class GetCodeTest(UnitTest):
+class GetCodeTest(unittest.TestCase):
     def test_validate_message_old_code(self) -> None:
         # lint-ignore: UseClassNameAsCodeRule
         self.assertEqual(_get_code("IG00 Old-school message", "SomeClassName"), "IG00")

--- a/fixit/common/tests/test_imports.py
+++ b/fixit/common/tests/test_imports.py
@@ -5,9 +5,8 @@
 
 import os
 import shutil
+import unittest
 from pathlib import Path
-
-from libcst.testing.utils import UnitTest
 
 from fixit.common.config import get_lint_config, get_rules_from_config
 from fixit.common.utils import (
@@ -24,7 +23,7 @@ DUMMY_SUBPACKAGE: str = "fixit.common.tests.dummy_package.dummy_subpackage"
 DUMMY_CONFIG_PATH: str = ".fixit.config.yaml"
 
 # Using dummy config file, test whether the rule import helpers work as expected.
-class ImportsTest(UnitTest):
+class ImportsTest(unittest.TestCase):
     def setUp(self) -> None:
         # We need to change the working directory so that the dummy config file is used.
         self.old_wd = os.getcwd()
@@ -79,7 +78,7 @@ class ImportsTest(UnitTest):
             imported_rule = find_and_import_rule("DummyRule1000", rules_packages)
 
 
-class AllowListTest(UnitTest):
+class AllowListTest(unittest.TestCase):
     def setUp(self) -> None:
         # We need to change the working directory so that the dummy config file is used.
         self.old_wd = os.getcwd()

--- a/fixit/common/tests/test_insert_suppressions.py
+++ b/fixit/common/tests/test_insert_suppressions.py
@@ -3,9 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
 from typing import Iterable
 
-from libcst.testing.utils import data_provider, UnitTest
+from parameterized import param, parameterized
 
 from fixit.common.insert_suppressions import (
     insert_suppressions,
@@ -15,169 +16,189 @@ from fixit.common.insert_suppressions import (
 from fixit.common.utils import dedent_with_lstrip
 
 
-class InsertSuppressionsTest(UnitTest):
-    @data_provider(
-        {
-            "simple_fixme": {
-                "before": dedent_with_lstrip(
-                    """
+class InsertSuppressionsTest(unittest.TestCase):
+    @parameterized.expand(
+        (
+            param(
+                "simple_fixme",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     # lint-fixme: IgnoredRule: Some message
                     def fn():
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=1,
-                        code="IgnoredRule",
-                        message="Some message",
-                    )
-                ],
-            },
-            "simple_ignore": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=1,
+                            code="IgnoredRule",
+                            message="Some message",
+                        )
+                    ],
+                },
+            ),
+            param(
+                "simple_ignore",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     # lint-ignore: IgnoredRule: Some message
                     def fn():
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.IGNORE,
-                        before_line=1,
-                        code="IgnoredRule",
-                        message="Some message",
-                    )
-                ],
-            },
-            "no_message": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.IGNORE,
+                            before_line=1,
+                            code="IgnoredRule",
+                            message="Some message",
+                        )
+                    ],
+                },
+            ),
+            param(
+                "no_message",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     # lint-fixme: IgnoredRule
                     def fn():
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=1,
-                        code="IgnoredRule",
-                    )
-                ],
-            },
-            "indented": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=1,
+                            code="IgnoredRule",
+                        )
+                    ],
+                },
+            ),
+            param(
+                "indented",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     def fn():
                         # lint-fixme: IgnoredRule: Some message
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=2,
-                        code="IgnoredRule",
-                        message="Some message",
-                    )
-                ],
-            },
-            "indented_tabs": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=2,
+                            code="IgnoredRule",
+                            message="Some message",
+                        )
+                    ],
+                },
+            ),
+            param(
+                "indented_tabs",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                     \t...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     def fn():
                     \t# lint-fixme: IgnoredRule: Some message
                     \t...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=2,
-                        code="IgnoredRule",
-                        message="Some message",
-                    )
-                ],
-            },
-            "multiple_comments": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=2,
+                            code="IgnoredRule",
+                            message="Some message",
+                        )
+                    ],
+                },
+            ),
+            param(
+                "multiple_comments",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     # lint-fixme: IgnoredRule: Some message
                     # lint-fixme: IgnoredRule1: Another message
                     def fn():
                         # lint-fixme: IgnoredRule2: Yet another
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=1,
-                        code="IgnoredRule",
-                        message="Some message",
                     ),
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=1,
-                        code="IgnoredRule1",
-                        message="Another message",
-                    ),
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=2,
-                        code="IgnoredRule2",
-                        message="Yet another",
-                    ),
-                ],
-            },
-            "multiline_comment": {
-                "before": dedent_with_lstrip(
-                    """
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=1,
+                            code="IgnoredRule",
+                            message="Some message",
+                        ),
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=1,
+                            code="IgnoredRule1",
+                            message="Another message",
+                        ),
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=2,
+                            code="IgnoredRule2",
+                            message="Yet another",
+                        ),
+                    ],
+                },
+            ),
+            param(
+                "multiline_comment",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     def fn():
                         # lint-fixme: IgnoredRule:
                         # lint: Some really long
@@ -187,30 +208,33 @@ class InsertSuppressionsTest(UnitTest):
                         # lint: wrapped
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=2,
-                        code="IgnoredRule",
-                        message=(
-                            "Some really long message that rambles on and on that "
-                            + "needs to be wrapped"
-                        ),
-                        max_lines=(2 ** 32),
-                    )
-                ],
-                "code_width": 30,
-            },
-            "newlines_in_message": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=2,
+                            code="IgnoredRule",
+                            message=(
+                                "Some really long message that rambles on and on that "
+                                + "needs to be wrapped"
+                            ),
+                            max_lines=(2 ** 32),
+                        )
+                    ],
+                    "code_width": 30,
+                },
+            ),
+            param(
+                "newlines_in_message",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     def fn():
                         # lint-fixme: IgnoredRule: This is the first line.
                         # lint: This is a subsequent line followed by a blank line.
@@ -218,25 +242,28 @@ class InsertSuppressionsTest(UnitTest):
                         # lint: And this is the last line.
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=2,
-                        code="IgnoredRule",
-                        message=(
-                            "This is the first line.\n"
-                            + "This is a subsequent line followed by a blank line.\n"
-                            + "\n"
-                            + "And this is the last line."
-                        ),
-                        max_lines=(2 ** 32),
-                    )
-                ],
-            },
-            "logical_line_continuation": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=2,
+                            code="IgnoredRule",
+                            message=(
+                                "This is the first line.\n"
+                                + "This is a subsequent line followed by a blank line.\n"
+                                + "\n"
+                                + "And this is the last line."
+                            ),
+                            max_lines=(2 ** 32),
+                        )
+                    ],
+                },
+            ),
+            param(
+                "logical_line_continuation",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     value = "abc"
                     value = \\
                         "abcd" + \\
@@ -244,9 +271,9 @@ class InsertSuppressionsTest(UnitTest):
                         "ijkl" + \\
                         "mnop"
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     value = "abc"
                     # lint-fixme: IgnoredRule: Some message
                     value = \\
@@ -255,21 +282,24 @@ class InsertSuppressionsTest(UnitTest):
                         "ijkl" + \\
                         "mnop"
                     """
-                ),
-                "comments": [
-                    # Line 4 isn't a logical line, so we expect that the comment will
-                    # be put on the first logical line above it.
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=4,
-                        code="IgnoredRule",
-                        message="Some message",
-                    )
-                ],
-            },
-            "logical_line_multiline_string": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        # Line 4 isn't a logical line, so we expect that the comment will
+                        # be put on the first logical line above it.
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=4,
+                            code="IgnoredRule",
+                            message="Some message",
+                        )
+                    ],
+                },
+            ),
+            param(
+                "logical_line_multiline_string",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     value = "abc"
                     value = '''
                         abcd
@@ -278,9 +308,9 @@ class InsertSuppressionsTest(UnitTest):
                         mnop
                     '''
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     value = "abc"
                     # lint-fixme: IgnoredRule: Some message
                     value = '''
@@ -290,127 +320,137 @@ class InsertSuppressionsTest(UnitTest):
                         mnop
                     '''
                     """
-                ),
-                "comments": [
-                    # Line 4 isn't a logical line, so we expect that the comment will
-                    # be put on the first logical line above it.
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=4,
-                        code="IgnoredRule",
-                        message="Some message",
-                    )
-                ],
-            },
-            "max_lines_first_block": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        # Line 4 isn't a logical line, so we expect that the comment will
+                        # be put on the first logical line above it.
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=4,
+                            code="IgnoredRule",
+                            message="Some message",
+                        )
+                    ],
+                },
+            ),
+            param(
+                "max_lines_first_block",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     # lint-fixme: IgnoredRule: first block ...
                     def fn():
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=1,
-                        code="IgnoredRule",
-                        message="first block\n\nsecond block\nthird block",
-                        max_lines=1,
-                    )
-                ],
-            },
-            "max_lines_between_blocks": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=1,
+                            code="IgnoredRule",
+                            message="first block\n\nsecond block\nthird block",
+                            max_lines=1,
+                        )
+                    ],
+                },
+            ),
+            param(
+                "max_lines_between_blocks",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     # lint-fixme: IgnoredRule: first block
                     # lint: ...
                     def fn():
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=1,
-                        code="IgnoredRule",
-                        message="first block\n\nsecond block\nthird block",
-                        max_lines=2,
-                    )
-                ],
-            },
-            "max_lines_subsequent_blocks": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=1,
+                            code="IgnoredRule",
+                            message="first block\n\nsecond block\nthird block",
+                            max_lines=2,
+                        )
+                    ],
+                },
+            ),
+            param(
+                "max_lines_subsequent_blocks",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     # lint-fixme: IgnoredRule: first block
                     # lint:
                     # lint: second block ...
                     def fn():
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=1,
-                        code="IgnoredRule",
-                        message="first block\n\nsecond block\nthird block",
-                        max_lines=3,
-                    )
-                ],
-            },
-            # In this example the last visible line wouldn't normally need to be
-            # truncated, but we don't quite have enough space for the "[...]" ellipsis
-            # at the end.
-            "max_lines_requires_trimming": {
-                "before": dedent_with_lstrip(
-                    """
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=1,
+                            code="IgnoredRule",
+                            message="first block\n\nsecond block\nthird block",
+                            max_lines=3,
+                        )
+                    ],
+                },
+            ),
+            param(
+                "max_lines_requires_trimming",
+                **{
+                    "before": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "after": dedent_with_lstrip(
-                    """
+                    ),
+                    "after": dedent_with_lstrip(
+                        """
                     # lint-fixme: IgnoredRule: first line
                     # lint: second line which is too ...
                     def fn():
                         ...
                     """
-                ),
-                "comments": [
-                    SuppressionComment(
-                        kind=SuppressionCommentKind.FIXME,
-                        before_line=1,
-                        code="IgnoredRule",
-                        message="first line\nsecond line which is too long\nlast line",
-                        max_lines=2,
-                    )
-                ],
-                "code_width": 40,  # the truncated comment is 38 characters long (<40)
-            },
-        }
+                    ),
+                    "comments": [
+                        SuppressionComment(
+                            kind=SuppressionCommentKind.FIXME,
+                            before_line=1,
+                            code="IgnoredRule",
+                            message="first line\nsecond line which is too long\nlast line",
+                            max_lines=2,
+                        )
+                    ],
+                    "code_width": 40,  # the truncated comment is 38 characters long (<40)
+                },
+            ),
+        )
     )
     def test_insert_suppressions(
         self,
-        *,
+        _name: str,
         before: str,
         after: str,
         comments: Iterable[SuppressionComment],

--- a/fixit/common/tests/test_line_mapping.py
+++ b/fixit/common/tests/test_line_mapping.py
@@ -4,31 +4,37 @@
 # LICENSE file in the root directory of this source tree.
 
 import tokenize
+import unittest
 from io import BytesIO
 from typing import Mapping
 
-from libcst.testing.utils import data_provider, UnitTest
+from parameterized import param, parameterized
 
 from fixit.common.line_mapping import LineMappingInfo
 from fixit.common.utils import dedent_with_lstrip
 
 
-class LineMappingInfoTest(UnitTest):
-    @data_provider(
-        {
-            "simple": {
-                "code": dedent_with_lstrip(
-                    """
+class LineMappingInfoTest(unittest.TestCase):
+    @parameterized.expand(
+        (
+            param(
+                "simple",
+                **{
+                    "code": dedent_with_lstrip(
+                        """
                     def fn():
                         ...
                     """
-                ),
-                "physical_to_logical": {1: 1, 2: 2, 3: 3},
-                "next_non_empty_logical_line": {1: 1, 2: 2, 3: 3},
-            },
-            "comments": {
-                "code": dedent_with_lstrip(
-                    """
+                    ),
+                    "physical_to_logical": {1: 1, 2: 2, 3: 3},
+                    "next_non_empty_logical_line": {1: 1, 2: 2, 3: 3},
+                },
+            ),
+            param(
+                "comments",
+                **{
+                    "code": dedent_with_lstrip(
+                        """
                     # comment with
                     # multiple
                     # lines
@@ -36,21 +42,24 @@ class LineMappingInfoTest(UnitTest):
                         # comment
                         ...
                     """
-                ),
-                "physical_to_logical": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7},
-                "next_non_empty_logical_line": {
-                    1: 4,
-                    2: 4,
-                    3: 4,
-                    4: 4,
-                    5: 6,
-                    6: 6,
-                    7: 7,
+                    ),
+                    "physical_to_logical": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7},
+                    "next_non_empty_logical_line": {
+                        1: 4,
+                        2: 4,
+                        3: 4,
+                        4: 4,
+                        5: 6,
+                        6: 6,
+                        7: 7,
+                    },
                 },
-            },
-            "blank_lines": {
-                "code": dedent_with_lstrip(
-                    """
+            ),
+            param(
+                "blank_lines",
+                **{
+                    "code": dedent_with_lstrip(
+                        """
 
 
                     def fn():
@@ -58,21 +67,24 @@ class LineMappingInfoTest(UnitTest):
 
                         ...
                     """
-                ),
-                "physical_to_logical": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7},
-                "next_non_empty_logical_line": {
-                    1: 3,
-                    2: 3,
-                    3: 3,
-                    4: 6,
-                    5: 6,
-                    6: 6,
-                    7: 7,
+                    ),
+                    "physical_to_logical": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7},
+                    "next_non_empty_logical_line": {
+                        1: 3,
+                        2: 3,
+                        3: 3,
+                        4: 6,
+                        5: 6,
+                        6: 6,
+                        7: 7,
+                    },
                 },
-            },
-            "line_continuation": {
-                "code": dedent_with_lstrip(
-                    """
+            ),
+            param(
+                "line_continuation",
+                **{
+                    "code": dedent_with_lstrip(
+                        """
                     value = "abc"
                     value = \\
                         "abcd" + \\
@@ -80,21 +92,24 @@ class LineMappingInfoTest(UnitTest):
                         "ijkl" + \\
                         "mnop"
                     """
-                ),
-                "physical_to_logical": {1: 1, 2: 2, 3: 2, 4: 2, 5: 2, 6: 2, 7: 7},
-                "next_non_empty_logical_line": {
-                    1: 1,
-                    2: 2,
-                    3: 7,
-                    4: 7,
-                    5: 7,
-                    6: 7,
-                    7: 7,
+                    ),
+                    "physical_to_logical": {1: 1, 2: 2, 3: 2, 4: 2, 5: 2, 6: 2, 7: 7},
+                    "next_non_empty_logical_line": {
+                        1: 1,
+                        2: 2,
+                        3: 7,
+                        4: 7,
+                        5: 7,
+                        6: 7,
+                        7: 7,
+                    },
                 },
-            },
-            "multiline_string": {
-                "code": dedent_with_lstrip(
-                    """
+            ),
+            param(
+                "multiline_string",
+                **{
+                    "code": dedent_with_lstrip(
+                        """
                     value = "abc"
                     value = '''
                         abcd
@@ -103,24 +118,34 @@ class LineMappingInfoTest(UnitTest):
                         mnop
                     '''
                     """
-                ),
-                "physical_to_logical": {1: 1, 2: 2, 3: 2, 4: 2, 5: 2, 6: 2, 7: 2, 8: 8},
-                "next_non_empty_logical_line": {
-                    1: 1,
-                    2: 2,
-                    3: 8,
-                    4: 8,
-                    5: 8,
-                    6: 8,
-                    7: 8,
-                    8: 8,
+                    ),
+                    "physical_to_logical": {
+                        1: 1,
+                        2: 2,
+                        3: 2,
+                        4: 2,
+                        5: 2,
+                        6: 2,
+                        7: 2,
+                        8: 8,
+                    },
+                    "next_non_empty_logical_line": {
+                        1: 1,
+                        2: 2,
+                        3: 8,
+                        4: 8,
+                        5: 8,
+                        6: 8,
+                        7: 8,
+                        8: 8,
+                    },
                 },
-            },
-        }
+            ),
+        )
     )
     def test_line_mapping(
         self,
-        *,
+        _name: str,
         code: str,
         physical_to_logical: Mapping[int, int],
         next_non_empty_logical_line: Mapping[int, int],

--- a/fixit/common/tests/test_pseudo_rule.py
+++ b/fixit/common/tests/test_pseudo_rule.py
@@ -6,10 +6,9 @@
 import ast
 import io
 import tokenize
+import unittest
 from pathlib import Path
 from typing import Iterable
-
-from libcst.testing.utils import UnitTest
 
 from fixit.common.base import LintConfig
 from fixit.common.pseudo_rule import PseudoContext, PseudoLintRule
@@ -23,7 +22,7 @@ DUMMY_LINT_CODE = "DummyLintRule"
 DUMMY_LINT_MESSAGE = "dummy lint message"
 
 
-class PseudoContextTest(UnitTest):
+class PseudoContextTest(unittest.TestCase):
     def setUp(self) -> None:
         self.dummy_tokens = tuple(tokenize.tokenize(io.BytesIO(DUMMY_SOURCE).readline))
         self.dummy_ast_tree = ast.parse(DUMMY_SOURCE)
@@ -47,7 +46,7 @@ class PseudoContextTest(UnitTest):
         self.assertIsNot(partial_context.ast_tree, self.dummy_ast_tree)
 
 
-class PseudoLintRuleTest(UnitTest):
+class PseudoLintRuleTest(unittest.TestCase):
     def test_pseudo_lint_rule(self) -> None:
         class DummyLintRuleReport(BaseLintRuleReport):
             pass

--- a/fixit/common/tests/test_report.py
+++ b/fixit/common/tests/test_report.py
@@ -9,7 +9,7 @@ import unittest
 from pathlib import Path
 
 import libcst as cst
-from parameterized import param, parameterized
+from parameterized import parameterized
 
 from fixit.common.report import AstLintRuleReport, BaseLintRuleReport, CstLintRuleReport
 

--- a/fixit/common/tests/test_report.py
+++ b/fixit/common/tests/test_report.py
@@ -5,18 +5,20 @@
 
 import ast
 import pickle
+import unittest
 from pathlib import Path
 
 import libcst as cst
-from libcst.testing.utils import data_provider, UnitTest
+from parameterized import param, parameterized
 
 from fixit.common.report import AstLintRuleReport, BaseLintRuleReport, CstLintRuleReport
 
 
-class LintRuleReportTest(UnitTest):
-    @data_provider(
-        {
-            "AstLintRuleReport": [
+class LintRuleReportTest(unittest.TestCase):
+    @parameterized.expand(
+        (
+            (
+                "AstLintRuleReport",
                 AstLintRuleReport(
                     file_path=Path("fake/path.py"),
                     node=ast.parse(""),
@@ -24,9 +26,10 @@ class LintRuleReportTest(UnitTest):
                     message="some message",
                     line=1,
                     column=1,
-                )
-            ],
-            "CstLintRuleReport": [
+                ),
+            ),
+            (
+                "CstLintRuleReport",
                 CstLintRuleReport(
                     file_path=Path("fake/path.py"),
                     node=cst.parse_statement("pass\n"),
@@ -36,10 +39,10 @@ class LintRuleReportTest(UnitTest):
                     column=1,
                     module=cst.MetadataWrapper(cst.parse_module(b"pass\n")),
                     module_bytes=b"pass\n",
-                )
-            ],
-        }
+                ),
+            ),
+        )
     )
-    def test_is_not_pickleable(self, report: BaseLintRuleReport) -> None:
+    def test_is_not_pickleable(self, _name: str, report: BaseLintRuleReport) -> None:
         with self.assertRaises(pickle.PicklingError):
             pickle.dumps(report)

--- a/fixit/common/tests/test_unused_suppressions.py
+++ b/fixit/common/tests/test_unused_suppressions.py
@@ -2,12 +2,13 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+import unittest
 from pathlib import Path
 from typing import Collection, List, Optional, Type
 
 import libcst as cst
 from libcst.metadata import MetadataWrapper
-from libcst.testing.utils import data_provider, UnitTest
+from parameterized import param, parameterized
 
 from fixit.common.base import CstContext, CstLintRule, LintConfig
 from fixit.common.comments import CommentInfo
@@ -35,277 +36,319 @@ class UsedRule2(CstLintRule):
 FILE_PATH: Path = Path("fake/path.py")
 
 
-class RemoveUnusedSuppressionsRuleTest(UnitTest):
-    @data_provider(
-        {
-            "used_suppression_one_code_oneline": {
-                "source": dedent_with_lstrip(
-                    """
+class RemoveUnusedSuppressionsRuleTest(unittest.TestCase):
+    @parameterized.expand(
+        (
+            param(
+                "used_suppression_one_code_oneline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule],
-                "rules_without_report": [],
-                "suppressed_line": 2,
-                "expected_unused_suppressions_report_messages": [],
-            },
-            "used_suppression_one_code_oneline_with_reason": {
-                "source": dedent_with_lstrip(
-                    """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule],
+                    "rules_without_report": [],
+                    "suppressed_line": 2,
+                    "expected_unused_suppressions_report_messages": [],
+                },
+            ),
+            param(
+                "used_suppression_one_code_oneline_with_reason",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule: reason blah.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule],
-                "rules_without_report": [],
-                "suppressed_line": 2,
-                "expected_unused_suppressions_report_messages": [],
-            },
-            "used_suppression_one_code_multiline": {
-                "source": dedent_with_lstrip(
-                    """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule],
+                    "rules_without_report": [],
+                    "suppressed_line": 2,
+                    "expected_unused_suppressions_report_messages": [],
+                },
+            ),
+            param(
+                "used_suppression_one_code_multiline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule: reason
                     # lint: reason continued blah
                     # lint: blah blah.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule],
-                "rules_without_report": [],
-                "suppressed_line": 4,
-                "expected_unused_suppressions_report_messages": [],
-            },
-            "used_suppression_many_codes_oneline": {
-                "source": dedent_with_lstrip(
-                    """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule],
+                    "rules_without_report": [],
+                    "suppressed_line": 4,
+                    "expected_unused_suppressions_report_messages": [],
+                },
+            ),
+            param(
+                "used_suppression_many_codes_oneline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule, UsedRule2
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [],
-                "suppressed_line": 2,
-                "expected_unused_suppressions_report_messages": [],
-            },
-            "used_suppression_many_codes_multiline": {
-                "source": dedent_with_lstrip(
-                    """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [],
+                    "suppressed_line": 2,
+                    "expected_unused_suppressions_report_messages": [],
+                },
+            ),
+            param(
+                "used_suppression_many_codes_multiline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule, UsedRule2:
                     # lint: reason blah blah.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [],
-                "suppressed_line": 3,
-                "expected_unused_suppressions_report_messages": [],
-            },
-            "unused_suppression_one_code_oneline": {
-                "source": dedent_with_lstrip(
-                    """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [],
+                    "suppressed_line": 3,
+                    "expected_unused_suppressions_report_messages": [],
+                },
+            ),
+            param(
+                "unused_suppression_one_code_oneline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule: reason blah blah.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule],
-                "rules_without_report": [UsedRule],
-                "suppressed_line": 2,
-                "expected_unused_suppressions_report_messages": [
-                    UNUSED_SUPPRESSION_COMMENT_MESSAGE
-                ],
-                "expected_replacements": [
-                    dedent_with_lstrip(
-                        """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule],
+                    "rules_without_report": [UsedRule],
+                    "suppressed_line": 2,
+                    "expected_unused_suppressions_report_messages": [
+                        UNUSED_SUPPRESSION_COMMENT_MESSAGE
+                    ],
+                    "expected_replacements": [
+                        dedent_with_lstrip(
+                            """
                     foo = bar
                     """
-                    )
-                ],
-            },
-            "unused_suppression_one_code_multiline": {
-                "source": dedent_with_lstrip(
-                    """
+                        )
+                    ],
+                },
+            ),
+            param(
+                "unused_suppression_one_code_multiline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule: reason
                     # lint: reason continued.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule],
-                "rules_without_report": [UsedRule],
-                "suppressed_line": 3,
-                "expected_unused_suppressions_report_messages": [
-                    UNUSED_SUPPRESSION_COMMENT_MESSAGE
-                ],
-                "expected_replacements": [
-                    dedent_with_lstrip(
-                        """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule],
+                    "rules_without_report": [UsedRule],
+                    "suppressed_line": 3,
+                    "expected_unused_suppressions_report_messages": [
+                        UNUSED_SUPPRESSION_COMMENT_MESSAGE
+                    ],
+                    "expected_replacements": [
+                        dedent_with_lstrip(
+                            """
                     foo = bar
                     """
-                    )
-                ],
-            },
-            "unused_suppression_many_codes_oneline": {
-                "source": dedent_with_lstrip(
-                    """
+                        )
+                    ],
+                },
+            ),
+            param(
+                "unused_suppression_many_codes_oneline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule, UsedRule2: reason
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [UsedRule],
-                "suppressed_line": 2,
-                "expected_unused_suppressions_report_messages": [
-                    UNUSED_SUPPRESSION_CODES_IN_COMMENT_MESSAGE.format(
-                        lint_codes="UsedRule"
-                    )
-                ],
-                "expected_replacements": [
-                    dedent_with_lstrip(
-                        """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [UsedRule],
+                    "suppressed_line": 2,
+                    "expected_unused_suppressions_report_messages": [
+                        UNUSED_SUPPRESSION_CODES_IN_COMMENT_MESSAGE.format(
+                            lint_codes="UsedRule"
+                        )
+                    ],
+                    "expected_replacements": [
+                        dedent_with_lstrip(
+                            """
                 # lint-ignore: UsedRule2: reason
                 foo = bar
                 """
-                    )
-                ],
-            },
-            "unused_suppression_many_codes_multiline": {
-                "source": dedent_with_lstrip(
-                    """
+                        )
+                    ],
+                },
+            ),
+            param(
+                "unused_suppression_many_codes_multiline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule, UsedRule2: reason
                     # lint: reason continued.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [UsedRule],
-                "suppressed_line": 3,
-                "expected_unused_suppressions_report_messages": [
-                    UNUSED_SUPPRESSION_CODES_IN_COMMENT_MESSAGE.format(
-                        lint_codes="UsedRule"
-                    )
-                ],
-                "expected_replacements": [
-                    dedent_with_lstrip(
-                        """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [UsedRule],
+                    "suppressed_line": 3,
+                    "expected_unused_suppressions_report_messages": [
+                        UNUSED_SUPPRESSION_CODES_IN_COMMENT_MESSAGE.format(
+                            lint_codes="UsedRule"
+                        )
+                    ],
+                    "expected_replacements": [
+                        dedent_with_lstrip(
+                            """
                 # lint-ignore: UsedRule2: reason reason
                 # lint: continued.
                 foo = bar
                 """
-                    )
-                ],
-            },
-            "unused_suppression_many_codes_all_unused": {
-                "source": dedent_with_lstrip(
-                    """
+                        )
+                    ],
+                },
+            ),
+            param(
+                "unused_suppression_many_codes_all_unused",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule, UsedRule2: reason
                     # lint: reason continued.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [UsedRule, UsedRule2],
-                "suppressed_line": 3,
-                "expected_unused_suppressions_report_messages": [
-                    UNUSED_SUPPRESSION_COMMENT_MESSAGE
-                ],
-                "expected_replacements": [
-                    dedent_with_lstrip(
-                        """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [UsedRule, UsedRule2],
+                    "suppressed_line": 3,
+                    "expected_unused_suppressions_report_messages": [
+                        UNUSED_SUPPRESSION_COMMENT_MESSAGE
+                    ],
+                    "expected_replacements": [
+                        dedent_with_lstrip(
+                            """
                         foo = bar
                         """
-                    )
-                ],
-            },
-            "multiple_suppressions": {
-                "source": dedent_with_lstrip(
-                    """
+                        )
+                    ],
+                },
+            ),
+            param(
+                "multiple_suppressions",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule: first reason
                     # lint: first reason continued.
                     # lint-ignore: UsedRule2: second reason
                     # lint: second reason continued.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [UsedRule],
-                "suppressed_line": 5,
-                "expected_unused_suppressions_report_messages": [
-                    UNUSED_SUPPRESSION_COMMENT_MESSAGE
-                ],
-                "expected_replacements": [
-                    dedent_with_lstrip(
-                        """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [UsedRule],
+                    "suppressed_line": 5,
+                    "expected_unused_suppressions_report_messages": [
+                        UNUSED_SUPPRESSION_COMMENT_MESSAGE
+                    ],
+                    "expected_replacements": [
+                        dedent_with_lstrip(
+                            """
                         # lint-ignore: UsedRule2: second reason
                         # lint: second reason continued.
                         foo = bar
                         """
-                    )
-                ],
-            },
-            "multiple_unused_suppressions": {
-                "source": dedent_with_lstrip(
-                    """
+                        )
+                    ],
+                },
+            ),
+            param(
+                "multiple_unused_suppressions",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UsedRule: first reason
                     # lint: first reason continued.
                     # lint-ignore: UsedRule2: second reason
                     # lint: second reason continued.
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [UsedRule, UsedRule2],
-                "suppressed_line": 5,
-                "expected_unused_suppressions_report_messages": [
-                    UNUSED_SUPPRESSION_COMMENT_MESSAGE,
-                    UNUSED_SUPPRESSION_COMMENT_MESSAGE,
-                ],
-                "expected_replacements": [
-                    dedent_with_lstrip(
-                        """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [UsedRule, UsedRule2],
+                    "suppressed_line": 5,
+                    "expected_unused_suppressions_report_messages": [
+                        UNUSED_SUPPRESSION_COMMENT_MESSAGE,
+                        UNUSED_SUPPRESSION_COMMENT_MESSAGE,
+                    ],
+                    "expected_replacements": [
+                        dedent_with_lstrip(
+                            """
                         # lint-ignore: UsedRule2: second reason
                         # lint: second reason continued.
                         foo = bar
                         """
-                    ),
-                    dedent_with_lstrip(
-                        """
+                        ),
+                        dedent_with_lstrip(
+                            """
                         # lint-ignore: UsedRule: first reason
                         # lint: first reason continued.
                         foo = bar
                         """
-                    ),
-                ],
-            },
-            "suppressions_with_unlinted_codes_oneline": {
-                "source": dedent_with_lstrip(
-                    """
+                        ),
+                    ],
+                },
+            ),
+            param(
+                "suppressions_with_unlinted_codes_oneline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UnusedRule
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [],
-                "suppressed_line": 2,
-                "expected_unused_suppressions_report_messages": [],
-            },
-            "suppressions_with_unlinted_codes_multiline": {
-                "source": dedent_with_lstrip(
-                    """
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [],
+                    "suppressed_line": 2,
+                    "expected_unused_suppressions_report_messages": [],
+                },
+            ),
+            param(
+                "suppressions_with_unlinted_codes_multiline",
+                **{
+                    "source": dedent_with_lstrip(
+                        """
                     # lint-ignore: UnusedRule: reason
                     # lint: reason continued
                     foo = bar
                     """
-                ).encode(),
-                "rules_in_lint_run": [UsedRule, UsedRule2],
-                "rules_without_report": [],
-                "suppressed_line": 3,
-                "expected_unused_suppressions_report_messages": [],
-            },
-        }
+                    ).encode(),
+                    "rules_in_lint_run": [UsedRule, UsedRule2],
+                    "rules_without_report": [],
+                    "suppressed_line": 3,
+                    "expected_unused_suppressions_report_messages": [],
+                },
+            ),
+        )
     )
     def test(
         self,
-        *,
+        _name: str,
         source: bytes,
         rules_in_lint_run: Collection[Type[CstLintRule]],
         rules_without_report: Collection[Type[CstLintRule]],

--- a/fixit/tests/test_import_constraints.py
+++ b/fixit/tests/test_import_constraints.py
@@ -3,12 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from libcst.testing.utils import UnitTest
+
+import unittest
 
 from fixit.rules.import_constraints import _ImportConfig
 
 
-class ImportConstraintsRuleConfigTest(UnitTest):
+class ImportConstraintsRuleConfigTest(unittest.TestCase):
     def test_at_least_one_rule(self) -> None:
         # Settings must have at least one rule
         with self.assertRaisesRegex(ValueError, "at least one"):

--- a/fixit/tests/test_rule_lint_engine.py
+++ b/fixit/tests/test_rule_lint_engine.py
@@ -3,10 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
 from pathlib import Path
 
 import libcst as cst
-from libcst.testing.utils import data_provider, UnitTest
+from parameterized import param, parameterized
 
 from fixit import rule_lint_engine
 from fixit.common.base import CstLintRule, LintConfig
@@ -47,63 +48,84 @@ class ParenthesizeAttributeLintRule(CstLintRule):
             )
 
 
-class RuleLintEngineTest(UnitTest):
-    @data_provider(
-        {
-            "good_call": {
-                "source": b"good_call()\n",
-                "use_ignore_byte_markers": False,
-                "use_ignore_comments": False,
-                "expected_report_count": 0,
-                "use_noqa": False,
-            },
-            "bad_call": {
-                "source": b"bad_call()\n",
-                "use_ignore_byte_markers": False,
-                "use_ignore_comments": False,
-                "expected_report_count": 1,
-                "use_noqa": False,
-            },
-            "multiple_bad_calls": {
-                "source": b"bad_call()\nbad_call()\n",
-                "use_ignore_byte_markers": False,
-                "use_ignore_comments": False,
-                "expected_report_count": 2,
-                "use_noqa": False,
-            },
-            "bad_call_generated": {
-                "source": b"'''@gen" + b"erated'''\nbad_call()",
-                "use_ignore_byte_markers": True,
-                "use_ignore_comments": False,
-                "expected_report_count": 0,
-                "use_noqa": False,
-            },
-            "bad_call_noqa": {
-                "source": b"bad_call()  # noqa\n",
-                "use_ignore_byte_markers": False,
-                "use_ignore_comments": True,
-                "expected_report_count": 0,
-                "use_noqa": True,
-            },
-            "bad_call_noqa_mixed": {
-                "source": b"bad_call()  # noqa\nbad_call()  # missing noqa comment\n",
-                "use_ignore_byte_markers": False,
-                "use_ignore_comments": True,
-                "expected_report_count": 1,
-                "use_noqa": True,
-            },
-            "bad_call_noqa_file": {
-                "source": b"# noqa-file: BadCallCstLintRule: Test case\nbad_call()\nbad_call()\n",
-                "use_ignore_byte_markers": False,
-                "use_ignore_comments": True,
-                "expected_report_count": 0,
-                "use_noqa": True,
-            },
-        }
+class RuleLintEngineTest(unittest.TestCase):
+    @parameterized.expand(
+        (
+            param(
+                "good_call",
+                **{
+                    "source": b"good_call()\n",
+                    "use_ignore_byte_markers": False,
+                    "use_ignore_comments": False,
+                    "expected_report_count": 0,
+                    "use_noqa": False,
+                },
+            ),
+            param(
+                "bad_call",
+                **{
+                    "source": b"bad_call()\n",
+                    "use_ignore_byte_markers": False,
+                    "use_ignore_comments": False,
+                    "expected_report_count": 1,
+                    "use_noqa": False,
+                },
+            ),
+            param(
+                "multiple_bad_calls",
+                **{
+                    "source": b"bad_call()\nbad_call()\n",
+                    "use_ignore_byte_markers": False,
+                    "use_ignore_comments": False,
+                    "expected_report_count": 2,
+                    "use_noqa": False,
+                },
+            ),
+            param(
+                "bad_call_generated",
+                **{
+                    "source": b"'''@gen" + b"erated'''\nbad_call()",
+                    "use_ignore_byte_markers": True,
+                    "use_ignore_comments": False,
+                    "expected_report_count": 0,
+                    "use_noqa": False,
+                },
+            ),
+            param(
+                "bad_call_noqa",
+                **{
+                    "source": b"bad_call()  # noqa\n",
+                    "use_ignore_byte_markers": False,
+                    "use_ignore_comments": True,
+                    "expected_report_count": 0,
+                    "use_noqa": True,
+                },
+            ),
+            param(
+                "bad_call_noqa_mixed",
+                **{
+                    "source": b"bad_call()  # noqa\nbad_call()  # missing noqa comment\n",
+                    "use_ignore_byte_markers": False,
+                    "use_ignore_comments": True,
+                    "expected_report_count": 1,
+                    "use_noqa": True,
+                },
+            ),
+            param(
+                "bad_call_noqa_file",
+                **{
+                    "source": b"# noqa-file: BadCallCstLintRule: Test case\nbad_call()\nbad_call()\n",
+                    "use_ignore_byte_markers": False,
+                    "use_ignore_comments": True,
+                    "expected_report_count": 0,
+                    "use_noqa": True,
+                },
+            ),
+        )
     )
     def test_lint_file(
         self,
-        *,
+        _name: str,
         source: bytes,
         use_ignore_byte_markers: bool,
         use_ignore_comments: bool,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ sphinx-rtd-theme>=0.5.0
 prompt-toolkit>=2.0.9
 tox>=3.14.5
 diff_cover>=3.0.1
+parameterized>=0.8.1

--- a/stubs/parameterized.pyi
+++ b/stubs/parameterized.pyi
@@ -1,0 +1,1 @@
+# pyre-placeholder-stub


### PR DESCRIPTION
## Summary
In order to upgrade pyre I'd like to stop using libcst.testing.utils.data_provider and use parameterized instead

The former attempts to typecheck the decorator input against the test method, but currently that is not possible in python's type system.

This is a large change w/ no functional difference. I used this codemod to convert all the tests: https://gist.github.com/lpetre/05b729a0891427c2a9def8d1eda3153d

I've changed from this:
```
from libcst.testing.utils import data_provider, UnitTest
class FooTest(UnitTest):
   @data_provider({"name": {"keyword": "value"}})
   def test(self, *, keyword: str) -> None:
      pass
```

To this equivalent in parameterized:
```
import unittest
from parameterized import param, parameterized
class FooTest(unittest.TestCase):
   @parameterized([param("name", **{"keyword": "value"})])
   def test(self, _name:str, keyword: str) -> None:
      pass
```

## Test Plan
python -m unittest
