### PR TITLE
Upgrade pyre

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           pyre --version
-          pyre check
+          pyre -n check
 
   coverage:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,8 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-          pyre --preserve-pythonpath check
+          pyre --version
+          pyre check
 
   coverage:
     runs-on: ${{ matrix.os }}

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -5,5 +5,6 @@
     "exclude": [
         ".*/\\.tox/.*"
     ],
+    "workers": 3,
     "strict": true
 }

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -216,9 +216,7 @@ def run_ipc(
     Returns an IPCResult object.
     """
 
-    resolved_paths = (
-        os.path.join(prefix, p) if prefix else p for p in paths
-    )
+    resolved_paths = (os.path.join(prefix, p) if prefix else p for p in paths)
 
     full_repo_metadata_config = opts.full_repo_metadata_config
     metadata_caches: Optional[Mapping[str, Mapping["ProviderT", object]]] = None

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -145,8 +145,6 @@ def map_paths(
         # Don't spawn more processes than there are tasks. Multiprocessing is eager and
         # will spawn workers immediately even if there's no work for them to do.
         with multiprocessing.Pool(min(workers, len(tasks))) as pool:
-            # pyre: Pyre doesn't understand something about the typevars used in this
-            # pyre-fixme[6]: function call. I was unable to debug it.
             for result in pool.imap_unordered(_map_paths_worker, tasks):
                 yield result
 

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -217,19 +217,18 @@ def run_ipc(
     Returns an IPCResult object.
     """
 
-    # pyre-fixme[35]: Target cannot be annotated.
-    paths: Generator[str, None, None] = (
+    resolved_paths = (
         os.path.join(prefix, p) if prefix else p for p in paths
     )
 
     full_repo_metadata_config = opts.full_repo_metadata_config
     metadata_caches: Optional[Mapping[str, Mapping["ProviderT", object]]] = None
     if full_repo_metadata_config is not None:
-        metadata_caches = get_repo_caches(paths, full_repo_metadata_config)
+        metadata_caches = get_repo_caches(resolved_paths, full_repo_metadata_config)
 
     results_iter: Iterator[Sequence[str]] = map_paths(
         get_file_lint_result_json,
-        paths,
+        resolved_paths,
         opts,
         workers=workers,
         metadata_caches=metadata_caches,
@@ -240,7 +239,7 @@ def run_ipc(
         for result in results:
             print(result)
 
-    return IPCResult(list(paths))
+    return IPCResult(list(resolved_paths))
 
 
 def ipc_main(opts: LintOpts) -> IPCResult:

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -77,6 +77,8 @@ def find_files(paths: Iterable[Union[str, Path]]) -> Iterator[str]:
 
 
 # Multiprocessing can only pass one argument. Wrap `operation` to provide this.
+# pyre-fixme[34]: `Variable[_MapPathsOperationResultT]` isn't present in the
+#  function's parameters.
 def _map_paths_worker(args: _MapPathsWorkerArgsT) -> _MapPathsOperationResultT:
     operation, path, config, metadata_caches = args
     return operation(Path(path), config, metadata_caches)
@@ -89,6 +91,8 @@ def map_paths(
     *,
     workers: Union[int, LintWorkers] = LintWorkers.CPU_COUNT,
     metadata_caches: Optional[Mapping[str, Mapping["ProviderT", object]]] = None,
+# pyre-fixme[34]: `Variable[_MapPathsOperationResultT]` isn't present in the
+#  function's parameters.
 ) -> Iterator[_MapPathsOperationResultT]:
     """
     Applies the given `operation` to each file path in `paths`.
@@ -213,6 +217,7 @@ def run_ipc(
     Returns an IPCResult object.
     """
 
+    # pyre-fixme[35]: Target cannot be annotated.
     paths: Generator[str, None, None] = (
         os.path.join(prefix, p) if prefix else p for p in paths
     )

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -20,7 +20,6 @@ from typing import (
     Callable,
     Collection,
     Dict,
-    Generator,
     Iterable,
     Iterator,
     List,

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -91,8 +91,8 @@ def map_paths(
     *,
     workers: Union[int, LintWorkers] = LintWorkers.CPU_COUNT,
     metadata_caches: Optional[Mapping[str, Mapping["ProviderT", object]]] = None,
-# pyre-fixme[34]: `Variable[_MapPathsOperationResultT]` isn't present in the
-#  function's parameters.
+    # pyre-fixme[34]: `Variable[_MapPathsOperationResultT]` isn't present in the
+    #  function's parameters.
 ) -> Iterator[_MapPathsOperationResultT]:
     """
     Applies the given `operation` to each file path in `paths`.

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -143,10 +143,7 @@ def apply_fix_operation(
                     updated_source = invoke_formatter(
                         get_lint_config().formatter, updated_source
                     )
-                with open(path, "wb") as f:
-                    # pyre-fixme[6]: Expected `Union[array.array[typing.Any],
-                    #  bytearray, bytes, ctypes._CData, memoryview, mmap.mmap]` for 1st
-                    #  param but got `str`.
+                with open(path, "w") as f:
                     f.write(updated_source)
         else:
             lint_result = get_one_patchable_report_for_path(
@@ -162,10 +159,7 @@ def apply_fix_operation(
             updated_source = lint_result.patched_source
             if updated_source != source:
                 # We don't do any formatting here as it's wasteful. The caller should handle formatting all files at the end.
-                with open(path, "wb") as f:
-                    # pyre-fixme[6]: Expected `Union[array.array[typing.Any],
-                    #  bytearray, bytes, ctypes._CData, memoryview, mmap.mmap]` for 1st
-                    #  param but got `str`.
+                with open(path, "w") as f:
                     f.write(updated_source)
 
                 patched_files_list.append(str(path))

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -144,6 +144,9 @@ def apply_fix_operation(
                         get_lint_config().formatter, updated_source
                     )
                 with open(path, "wb") as f:
+                    # pyre-fixme[6]: Expected `Union[array.array[typing.Any],
+                    #  bytearray, bytes, ctypes._CData, memoryview, mmap.mmap]` for 1st
+                    #  param but got `str`.
                     f.write(updated_source)
         else:
             lint_result = get_one_patchable_report_for_path(
@@ -160,6 +163,9 @@ def apply_fix_operation(
             if updated_source != source:
                 # We don't do any formatting here as it's wasteful. The caller should handle formatting all files at the end.
                 with open(path, "wb") as f:
+                    # pyre-fixme[6]: Expected `Union[array.array[typing.Any],
+                    #  bytearray, bytes, ctypes._CData, memoryview, mmap.mmap]` for 1st
+                    #  param but got `str`.
                     f.write(updated_source)
 
                 patched_files_list.append(str(path))

--- a/fixit/cli/full_repo_metadata.py
+++ b/fixit/cli/full_repo_metadata.py
@@ -37,11 +37,14 @@ class MetadataCacheErrorHandler(Handler):
                 if exc_type is TimeoutExpired:
                     self.timeout_paths += failed_paths
                 else:
+                    # pyre-fixme[6]: Expected `Type[Exception]` for 1st param but
+                    #  got `Type[BaseException]`.
                     self.other_exceptions[exc_type] += failed_paths
 
 
 def rules_require_metadata_cache(rules: LintRuleCollectionT) -> bool:
     return any(
+        # pyre-fixme[16]: `PseudoLintRule` has no attribute `requires_metadata_caches`.
         issubclass(r, CstLintRule) and getattr(r, "requires_metadata_caches")()
         for r in rules
     )

--- a/fixit/cli/tests/test_lint_opts.py
+++ b/fixit/cli/tests/test_lint_opts.py
@@ -28,6 +28,8 @@ class FakeLintSuccessReport(LintSuccessReportBase):
     reports: Collection[str]
 
     @staticmethod
+    # pyre-fixme[14]: `create_reports` overrides method defined in
+    #  `LintSuccessReportBase` inconsistently.
     def create_reports(
         path: Path,
         reports: Collection[BaseLintRuleReport],
@@ -44,6 +46,8 @@ class FakeLintFailureReport(LintFailureReportBase):
     reports: Collection[str]
 
     @staticmethod
+    # pyre-fixme[14]: `create_reports` overrides method defined in
+    #  `LintFailureReportBase` inconsistently.
     def create_reports(
         path: Path,
         reports: Collection[BaseLintRuleReport],

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -105,12 +105,14 @@ def get_lint_config() -> LintConfig:
     cwd = Path.cwd()
     for directory in (cwd, *cwd.parents):
         # Check for config file.
+        # pyre-fixme[58]: `/` is not supported for operand types `object` and `Path`.
         possible_config = directory / LINT_CONFIG_FILE_NAME
         if possible_config.is_file():
             with open(possible_config, "r") as f:
                 file_content = yaml.safe_load(f.read())
 
             if isinstance(file_content, dict):
+                # pyre-fixme[6]: Expected `Path` for 2nd param but got `object`.
                 config = get_validated_settings(file_content, directory)
                 break
 

--- a/fixit/common/generate_pyre_fixtures.py
+++ b/fixit/common/generate_pyre_fixtures.py
@@ -59,6 +59,7 @@ def gen_types_for_test_case(source_code: str, dest_path: Path) -> None:
         if "error" in data:
             raise PyreQueryError(cmd, data["error"])
         data = data["response"][0]
+        # pyre-fixme[35]: Target cannot be annotated.
         data: PyreData = _process_pyre_data(data)
         print(f"Writing output to {dest_path}")
         dest_path.write_text(json.dumps({"types": data["types"]}, indent=2))
@@ -77,12 +78,15 @@ def gen_types(rule: CstLintRule, rule_fixture_dir: Path) -> None:
             print(stdout)
             print(stderr)
         else:
+            # pyre-fixme[16]: `CstLintRule` has no attribute `__name__`.
             class_name = getattr(rule, "__name__")
             if hasattr(rule, "VALID"):
+                # pyre-fixme[16]: `CstLintRule` has no attribute `VALID`.
                 for idx, valid_tc in enumerate(getattr(rule, "VALID")):
                     path: Path = rule_fixture_dir / f"{class_name}_VALID_{idx}.json"
                     gen_types_for_test_case(source_code=valid_tc.code, dest_path=path)
             if hasattr(rule, "INVALID"):
+                # pyre-fixme[16]: `CstLintRule` has no attribute `INVALID`.
                 for idx, invalid_tc in enumerate(getattr(rule, "INVALID")):
                     path: Path = rule_fixture_dir / f"{class_name}_INVALID_{idx}.json"
                     gen_types_for_test_case(source_code=invalid_tc.code, dest_path=path)

--- a/fixit/common/generate_pyre_fixtures.py
+++ b/fixit/common/generate_pyre_fixtures.py
@@ -54,13 +54,11 @@ def gen_types_for_test_case(source_code: str, dest_path: Path) -> None:
         stdout, stderr, return_code = run_command(cmd)
         if return_code != 0:
             raise PyreQueryError(cmd, f"{stdout}\n{stderr}")
-        data = json.loads(stdout)
+        json_data = json.loads(stdout)
         # Check if error is a key in `data` since pyre may report errors this way.
-        if "error" in data:
-            raise PyreQueryError(cmd, data["error"])
-        data = data["response"][0]
-        # pyre-fixme[35]: Target cannot be annotated.
-        data: PyreData = _process_pyre_data(data)
+        if "error" in json_data:
+            raise PyreQueryError(cmd, json_data["error"])
+        data: PyreData = _process_pyre_data(json_data["response"][0])
         print(f"Writing output to {dest_path}")
         dest_path.write_text(json.dumps({"types": data["types"]}, indent=2))
 

--- a/fixit/common/report.py
+++ b/fixit/common/report.py
@@ -45,6 +45,7 @@ class BaseLintRuleReport(abc.ABC):
     def __repr__(self) -> str:
         return f"{self.line}:{self.column}: {self.code} {self.message}"
 
+    # pyre-fixme[15]: `__reduce__` overrides method defined in `object` inconsistently.
     def __reduce__(self) -> None:
         raise PicklingError(
             "Lint rule reports are potentially very complex objects. They can contain "

--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -143,6 +143,7 @@ def _gen_test_methods_for_rule(
         if rule.requires_metadata_caches():
             requires_fixtures = True
         if hasattr(rule, "VALID"):
+            # pyre-fixme[16]: `CstLintRule` has no attribute `VALID`.
             for idx, test_case in enumerate(getattr(rule, "VALID")):
                 name = f"test_VALID_{idx}"
                 valid_tcs[name] = test_case
@@ -151,6 +152,7 @@ def _gen_test_methods_for_rule(
                         fixture_subdir / f"{rule.__name__}_VALID_{idx}.json"
                     )
         if hasattr(rule, "INVALID"):
+            # pyre-fixme[16]: `CstLintRule` has no attribute `INVALID`.
             for idx, test_case in enumerate(getattr(rule, "INVALID")):
                 name = f"test_INVALID_{idx}"
                 invalid_tcs[name] = test_case
@@ -216,6 +218,7 @@ def add_lint_rule_tests_to_module(
     """
     for test_case in _gen_all_test_methods(rules, fixture_dir, rules_package):
         rule_name = test_case.rule.__name__
+        # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
         test_methods_to_add: Dict[str, Callable] = {}
 
         for test_method_name, test_method_data in test_case.test_methods.items():
@@ -229,6 +232,7 @@ def add_lint_rule_tests_to_module(
             ) -> None:
                 return getattr(self, custom_test_method_name)(data, rule, fixture_file)
 
+            # pyre-fixme[16]: Anonymous callable has no attribute `__name__`.
             test_method.__name__ = test_method_name
             test_methods_to_add[test_method_name] = test_method
 

--- a/fixit/common/tests/test_full_repo_metadata.py
+++ b/fixit/common/tests/test_full_repo_metadata.py
@@ -72,6 +72,8 @@ class FullRepoMetadataTest(UnitTest):
         ]
         all_calls = chain.from_iterable([(call.__bool__(), c) for c in calls])
 
+        # pyre-fixme[6]: Expected `Sequence[unittest.mock._Call]` for 1st param but
+        #  got `Iterator[typing.Any]`.
         gen_cache.assert_has_calls(all_calls)
 
     @patch("libcst.metadata.TypeInferenceProvider.gen_cache")

--- a/fixit/common/unused_suppressions.py
+++ b/fixit/common/unused_suppressions.py
@@ -149,6 +149,7 @@ class RemoveUnusedSuppressionsRule(CstLintRule):
                     )
 
     def _handle_node_with_leading_lines(self, node: cst.CSTNode) -> None:
+        # pyre-fixme[16]: `CSTNode` has no attribute `leading_lines`.
         if hasattr(node, "leading_lines") and getattr(node, "leading_lines"):
             self._handle_emptyline_sequence_attribute(node, "leading_lines")
 

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -87,6 +87,7 @@ class InvalidTestCase:
 
 def import_submodules(package: str, recursive: bool = True) -> Dict[str, ModuleType]:
     """Import all submodules of a module, recursively, including subpackages."""
+    # pyre-fixme[35]: Target cannot be annotated.
     package: ModuleType = importlib.import_module(package)
     results = {}
     # pyre-fixme[16]: `ModuleType` has no attribute `__path__`.
@@ -112,6 +113,7 @@ def import_distinct_rules_from_package(
     # Optional parameter `seen_names` accepts set of names that should not occur in this package.
     rules: LintRuleCollectionT = set()
     if seen_names is None:
+        # pyre-fixme[35]: Target cannot be annotated.
         seen_names: Set[str] = set()
     for _module_name, module in import_submodules(package).items():
         for name in dir(module):

--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -211,5 +211,6 @@ def lint_file_and_apply_patches(
         # pyre-fixme[60]: Concatenation not yet support for multiple variadic
         #  tuples: `*fixed_reports, *reports`.
         # pyre-fixme[6]: Expected `str` for 2nd param but got `bytes`.
-        reports=(*fixed_reports, *reports), patched_source=source
+        reports=(*fixed_reports, *reports),
+        patched_source=source,
     )

--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -67,6 +67,7 @@ def lint_file(
     caller.
     """
     # Get settings from the nearest `.fixit.config.yaml` file if necessary.
+    # pyre-fixme[35]: Target cannot be annotated.
     config: LintConfig = config if config is not None else get_lint_config()
 
     if use_ignore_byte_markers and any(
@@ -118,6 +119,7 @@ def lint_file(
     if pseudo_rules:
         psuedo_context = PseudoContext(file_path, source, tokens, ast_tree)
         for pr_cls in pseudo_rules:
+            # pyre-fixme[45]: Cannot instantiate abstract class `PseudoLintRule`.
             reports.extend(pr_cls(psuedo_context).lint_file())
 
     if ignore_info is not None:
@@ -206,5 +208,8 @@ def lint_file_and_apply_patches(
     # `reports` shouldn't contain any fixable reports at this point, so there should be
     # no overlap between `fixed_reports` and `reports`.
     return LintRuleReportsWithAppliedPatches(
+        # pyre-fixme[60]: Concatenation not yet support for multiple variadic
+        #  tuples: `*fixed_reports, *reports`.
+        # pyre-fixme[6]: Expected `str` for 2nd param but got `bytes`.
         reports=(*fixed_reports, *reports), patched_source=source
     )

--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -210,7 +210,7 @@ def lint_file_and_apply_patches(
     return LintRuleReportsWithAppliedPatches(
         # pyre-fixme[60]: Concatenation not yet support for multiple variadic
         #  tuples: `*fixed_reports, *reports`.
-        # pyre-fixme[6]: Expected `str` for 2nd param but got `bytes`.
         reports=(*fixed_reports, *reports),
+        # pyre-fixme[6]: Expected `str` for 2nd param but got `bytes`.
         patched_source=source,
     )

--- a/fixit/rules/explicit_frozen_dataclass.py
+++ b/fixit/rules/explicit_frozen_dataclass.py
@@ -242,7 +242,6 @@ class ExplicitFrozenDataclassRule(CstLintRule):
                     args = ()
                     func = decorator
 
-                # pyre-fixme[29]: `typing.Union[typing.Callable(tuple.__iter__)[[], typing.Iterator[Variable[_T_co](covariant)]], typing.Callable(typing.Sequence.__iter__)[[], typing.Iterator[cst._nodes.expression.Arg]]]` is not a function.
                 if not any(m.matches(arg.keyword, m.Name("frozen")) for arg in args):
                     new_decorator = cst.Call(
                         func=func,

--- a/fixit/rules/explicit_frozen_dataclass.py
+++ b/fixit/rules/explicit_frozen_dataclass.py
@@ -242,6 +242,9 @@ class ExplicitFrozenDataclassRule(CstLintRule):
                     args = ()
                     func = decorator
 
+                # pyre-fixme[6]: Expected `Union[cst._maybe_sentinel.MaybeSentinel,
+                #  cst._nodes.base.CSTNode, cst._removal_sentinel.RemovalSentinel]` for
+                #  1st param but got `Optional[cst._nodes.expression.Name]`.
                 if not any(m.matches(arg.keyword, m.Name("frozen")) for arg in args):
                     new_decorator = cst.Call(
                         func=func,

--- a/fixit/rules/use_fstring.py
+++ b/fixit/rules/use_fstring.py
@@ -196,6 +196,7 @@ class UseFstringRule(CstLintRule):
                         cst.FormattedStringExpression(
                             expression=cast(
                                 cst.BaseExpression,
+                                # pyre-fixme[16]: `Sequence` has no attribute `visit`.
                                 expressions[i - 1].visit(escape_transformer),
                             )
                         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
 isort>=4.3.20
 jupyter>=1.0.0
 nbsphinx>=0.7.1
-pyre-check==0.0.41
+pyre-check==0.9.9
 sphinx-rtd-theme>=0.5.0
 prompt-toolkit>=2.0.9
 tox>=3.14.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
 isort>=4.3.20
 jupyter>=1.0.0
 nbsphinx>=0.7.1
-pyre-check==0.9.9
+pyre-check==0.9.9; platform_system != "Windows"
 sphinx-rtd-theme>=0.5.0
 prompt-toolkit>=2.0.9
 tox>=3.14.5

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,11 @@ import setuptools
 # Grab the readme so that our package stays in sync with github.
 this_directory: str = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
+    # pyre-fixme[5]: Global expression must be annotated.
     long_description = f.read()
 
 # Grab the version constant so that libcst.tool stays in sync with this package.
+# pyre-fixme[9]: spec has type `ModuleSpec`; used as `Optional[ModuleSpec]`.
 spec: ModuleSpec = importlib.util.spec_from_file_location(
     "version", path.join(this_directory, "fixit/_version.py")
 )


### PR DESCRIPTION
This PR

 - upgrades pyre to 0.9.9 which brings a new type checking backend
- fixes some amount of type errors that 0.9.9 detects now
- suppresses the rest of the type errors
