### PR TITLE
Update github actions to run on more python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,125 +8,181 @@ on:
   pull_request:
 
 jobs:
+# Build the docs
   docs:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.8]
-        os: [ubuntu-latest]
-
+    needs: lint
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Env
-        run: |
-          python -VV
-      - name: Tox
-        run: |
-          python -m pip install tox
-          tox --version
-      - name: Sphinx
-        run: |
-          tox -e docs
-      - name: Upload
-        uses: actions/upload-artifact@v1
-        with:
-          name: fixit-docs
-          path: docs/build/
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
+    - run: pip install -e .
+    - uses: ts-graphviz/setup-graphviz@v1
+    - run: sphinx-build docs/source/ docs/build/
+    - name: Archive Docs
+      uses: actions/upload-artifact@v2
+      with:
+        name: fixit-docs
+        path: docs/build
 
+# Run fixit
   fixit:
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        os: [macOS-latest, ubuntu-latest, windows-latest]
-
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Env
-        run: |
-          python -VV
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/requirements-dev.txt') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/.github/workflows/build.yml') }}-${{ matrix.python-version }}
-      - name: Tox
-        run: |
-          python -m pip install tox
-          tox --version
-      - name: Lint
-        run: |
-          tox -e lint
-      - name: Test
-        run: |
-          tox -e $(python .github/scripts/tox_job.py)
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
+    - run: python -VV
+    - run: python -m fixit.cli.run_rules fixit
 
-  pyre:
+# Run unittests
+  test:
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
-        os: [ubuntu-latest]
-
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Pyre
-        run: |
-          python -m venv /tmp/fixit-env/
-          source /tmp/fixit-env/bin/activate
-          python -VV
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-          pyre --version
-          pyre -n check
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
+    - name: Run Tests
+      run: python setup.py test
 
+# Run linters
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
+    - run: flake8
+    - run: ufmt check .
+
+# Run pyre typechecker
+  typecheck:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
+    - run: pyre --version
+    - run: pyre -n check
+
+# Upload test coverage
   coverage:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.8]
-        os: [ubuntu-latest]
-
+    needs: lint
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Env
-        run: |
-          python -VV
-      - name: Tox
-        run: |
-          python -m pip install tox
-          tox --version
-      - name: coverage
-        run: |
-          tox -e coverage
-      - name: codecov
-        uses: codecov/codecov-action@v1
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
+    - name: Generate Coverage
+      run: |
+        coverage run setup.py test
+        coverage xml -i
+    - uses: codecov/codecov-action@v2
+      with:
+        files: coverage.xml
+        fail_ci_if_error: true
+        verbose: true
+    - name: Archive Coverage
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: coverage.xml
+
+# Build python package
+  build:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'setup.py') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        pip install --upgrade --upgrade-strategy eager build -r requirements.txt -r requirements-dev.txt
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 black>=21.10b0
-codecov>=2.0.15
 coverage>=4.5.4
 git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
 ufmt==1.3


### PR DESCRIPTION
Inspired by the CI actions in LibCST, this PR:
 - runs test, lint, and fixit in separate jobs
 - builds a distribution for pypi
 - runs on 3.9 and 3.10 python versions