### PR TITLE
Convert to pyre site-package support

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -5,6 +5,11 @@
     "exclude": [
         ".*/\\.tox/.*"
     ],
+    "search_path": [
+        {"site-package": "libcst"},
+        {"site-package": "importlib_resources"},
+        {"site-package": "flake8"}
+    ],
     "workers": 3,
     "strict": true
 }


### PR DESCRIPTION
## Summary

If you set a search path (for stubs etc) then pyre won't automatically include your site-packages, and you need to jump through big hoops to generate a .pyre_configuration (see https://github.com/Instagram/LibCST/blob/main/.github/workflows/build.yml#L84-L92)

Move to the new site-package feature in pyre to be explicit about the search path.

## Test Plan
CI
