### PR TITLE
CI isn't running in main because the branch was renamed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
   pull_request:


### PR DESCRIPTION
Running in main is important for coverage etc