### PR TITLE
Use ufmt to format code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,8 +73,8 @@ Start by setting up and activating a virtualenv:
     # If you're done with the virtualenv, you can leave it by running:
     deactivate
 
-We use `isort <https://isort.readthedocs.io/en/stable/>`_ and `black <https://black.readthedocs.io/en/stable/>`_
-to format code. To format changes to be conformant, run the following in the root:
+We use `ufmt <https://ufmt.omnilib.dev/en/stable/>`_ to format code. To format
+changes to be conformant, run the following in the root:
 
 .. code-block:: shell
 

--- a/fixit/cli/__init__.py
+++ b/fixit/cli/__init__.py
@@ -16,7 +16,6 @@ import warnings
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     Callable,
     Collection,
     Dict,
@@ -28,6 +27,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TYPE_CHECKING,
     TypeVar,
     Union,
 )
@@ -35,7 +35,7 @@ from typing import (
 import libcst as cst
 from libcst.metadata import MetadataWrapper
 
-from fixit.cli.args import LintWorkers, get_multiprocessing_parser
+from fixit.cli.args import get_multiprocessing_parser, LintWorkers
 from fixit.common.base import LintConfig
 from fixit.common.config import get_lint_config
 from fixit.common.full_repo_metadata import FullRepoMetadataConfig, get_repo_caches

--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -17,15 +17,14 @@ import time
 from dataclasses import dataclass
 from multiprocessing import Manager
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional
+from typing import Iterable, List, Mapping, Optional, TYPE_CHECKING
 
-from libcst import ParserSyntaxError, parse_module
+from libcst import parse_module, ParserSyntaxError
 from libcst.codemod._cli import invoke_formatter
 from libcst.metadata import MetadataWrapper
 
 from fixit.cli import find_files, map_paths
 from fixit.cli.args import (
-    LintWorkers,
     get_compact_parser,
     get_metadata_cache_parser,
     get_multiprocessing_parser,
@@ -34,6 +33,7 @@ from fixit.cli.args import (
     get_skip_autoformatter_parser,
     get_skip_ignore_byte_marker_parser,
     get_skip_ignore_comments_parser,
+    LintWorkers,
 )
 from fixit.cli.formatter import LintRuleReportFormatter
 from fixit.cli.full_repo_metadata import (
@@ -45,8 +45,8 @@ from fixit.common.config import get_lint_config
 from fixit.common.report import BaseLintRuleReport
 from fixit.common.utils import LintRuleCollectionT
 from fixit.rule_lint_engine import (
-    LintRuleReportsWithAppliedPatches,
     lint_file_and_apply_patches,
+    LintRuleReportsWithAppliedPatches,
 )
 
 

--- a/fixit/cli/args.py
+++ b/fixit/cli/args.py
@@ -12,9 +12,9 @@ from typing import List
 from fixit.common.base import LintRuleT
 from fixit.common.config import get_lint_config, get_rules_from_config
 from fixit.common.utils import (
-    LintRuleNotFoundError,
     find_and_import_rule,
     import_distinct_rules_from_package,
+    LintRuleNotFoundError,
 )
 
 

--- a/fixit/cli/full_repo_metadata.py
+++ b/fixit/cli/full_repo_metadata.py
@@ -4,9 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
-from logging import Handler, Logger, LogRecord, getLogger
+from logging import getLogger, Handler, Logger, LogRecord
 from subprocess import TimeoutExpired
-from typing import TYPE_CHECKING, DefaultDict, Iterable, List, Mapping, Type
+from typing import DefaultDict, Iterable, List, Mapping, Type, TYPE_CHECKING
 
 from libcst.metadata import TypeInferenceProvider
 

--- a/fixit/cli/insert_suppressions.py
+++ b/fixit/cli/insert_suppressions.py
@@ -17,9 +17,9 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Union
+from typing import Iterable, List, Mapping, Optional, TYPE_CHECKING, Union
 
-from libcst import ParserSyntaxError, parse_module
+from libcst import parse_module, ParserSyntaxError
 from libcst.codemod._cli import invoke_formatter
 from libcst.metadata import MetadataWrapper
 
@@ -41,9 +41,9 @@ from fixit.cli.utils import print_red
 from fixit.common.base import LintRuleT
 from fixit.common.config import get_lint_config
 from fixit.common.insert_suppressions import (
+    insert_suppressions,
     SuppressionComment,
     SuppressionCommentKind,
-    insert_suppressions,
 )
 from fixit.common.report import BaseLintRuleReport
 from fixit.rule_lint_engine import lint_file

--- a/fixit/cli/run_rules.py
+++ b/fixit/cli/run_rules.py
@@ -19,9 +19,9 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional
+from typing import Iterable, List, Mapping, Optional, TYPE_CHECKING
 
-from libcst import ParserSyntaxError, parse_module
+from libcst import parse_module, ParserSyntaxError
 from libcst.metadata import MetadataWrapper
 
 from fixit.cli import find_files, map_paths

--- a/fixit/cli/tests/test_formatter.py
+++ b/fixit/cli/tests/test_formatter.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import libcst as cst
 from libcst.testing.utils import UnitTest
 
-from fixit.cli.formatter import LintRuleReportFormatter, format_warning
+from fixit.cli.formatter import format_warning, LintRuleReportFormatter
 from fixit.common.report import BaseLintRuleReport, CstLintRuleReport
 
 

--- a/fixit/cli/tests/test_lint_opts.py
+++ b/fixit/cli/tests/test_lint_opts.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Collection, List, Optional, Sequence, cast
+from typing import cast, Collection, List, Optional, Sequence
 
 from libcst import Module
 from libcst.testing.utils import UnitTest

--- a/fixit/common/base.py
+++ b/fixit/common/base.py
@@ -7,7 +7,7 @@ import re
 from abc import ABCMeta
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, TYPE_CHECKING, Union
 
 import libcst as cst
 from libcst import BatchableCSTVisitor

--- a/fixit/common/cli/__init__.py
+++ b/fixit/common/cli/__init__.py
@@ -7,7 +7,7 @@
 For backwards compatibility.
 """
 
-from fixit.cli import IPCResult, LintOpts, find_files, ipc_main, map_paths
+from fixit.cli import find_files, ipc_main, IPCResult, LintOpts, map_paths
 
 
 __all__ = ["IPCResult", "LintOpts", "find_files", "ipc_main", "map_paths"]

--- a/fixit/common/config.py
+++ b/fixit/common/config.py
@@ -23,7 +23,7 @@ import yaml
 from jsonschema import validate
 
 from fixit.common.base import LintConfig
-from fixit.common.utils import LintRuleCollectionT, import_distinct_rules_from_package
+from fixit.common.utils import import_distinct_rules_from_package, LintRuleCollectionT
 
 
 LINT_CONFIG_FILE_NAME: Path = Path(".fixit.config.yaml")

--- a/fixit/common/full_repo_metadata.py
+++ b/fixit/common/full_repo_metadata.py
@@ -6,7 +6,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from itertools import chain, islice
-from typing import TYPE_CHECKING, Dict, Iterable, Mapping, Optional, Set
+from typing import Dict, Iterable, Mapping, Optional, Set, TYPE_CHECKING
 
 from libcst.metadata import FullRepoManager, TypeInferenceProvider
 

--- a/fixit/common/generate_pyre_fixtures.py
+++ b/fixit/common/generate_pyre_fixtures.py
@@ -7,11 +7,11 @@ import argparse
 import json
 import tempfile
 from pathlib import Path
-from typing import List, cast
+from typing import cast, List
 
 from libcst.metadata.type_inference_provider import (
-    PyreData,
     _process_pyre_data,
+    PyreData,
     run_command,
 )
 

--- a/fixit/common/testing.py
+++ b/fixit/common/testing.py
@@ -6,7 +6,7 @@
 import unittest
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Type, Union, cast
+from typing import Any, Callable, cast, Dict, Mapping, Optional, Sequence, Type, Union
 
 from libcst.metadata import MetadataWrapper
 
@@ -14,11 +14,11 @@ from fixit.common.base import CstLintRule
 from fixit.common.generate_pyre_fixtures import get_fixture_path
 from fixit.common.report import BaseLintRuleReport
 from fixit.common.utils import (
+    _dedent,
+    gen_type_inference_wrapper,
     InvalidTestCase,
     LintRuleCollectionT,
     ValidTestCase,
-    _dedent,
-    gen_type_inference_wrapper,
 )
 from fixit.rule_lint_engine import lint_file
 

--- a/fixit/common/tests/test_autofix.py
+++ b/fixit/common/tests/test_autofix.py
@@ -7,7 +7,7 @@ from typing import Callable, Union
 
 import libcst as cst
 from libcst.metadata import CodePosition, MetadataWrapper
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 from fixit.common.autofix import LintPatch
 

--- a/fixit/common/tests/test_full_repo_metadata.py
+++ b/fixit/common/tests/test_full_repo_metadata.py
@@ -9,7 +9,7 @@ from itertools import chain
 from pathlib import Path
 from subprocess import TimeoutExpired
 from typing import Dict, Mapping
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, MagicMock, patch
 
 from libcst.metadata import TypeInferenceProvider
 from libcst.metadata.base_provider import ProviderT

--- a/fixit/common/tests/test_ignores.py
+++ b/fixit/common/tests/test_ignores.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Container, Iterable, Tuple
 
 import libcst as cst
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 from fixit.common.comments import CommentInfo
 from fixit.common.ignores import IgnoreInfo

--- a/fixit/common/tests/test_imports.py
+++ b/fixit/common/tests/test_imports.py
@@ -11,11 +11,11 @@ from libcst.testing.utils import UnitTest
 
 from fixit.common.config import get_lint_config, get_rules_from_config
 from fixit.common.utils import (
-    DuplicateLintRuleNameError,
-    LintRuleNotFoundError,
     dedent_with_lstrip,
+    DuplicateLintRuleNameError,
     find_and_import_rule,
     import_rule_from_package,
+    LintRuleNotFoundError,
 )
 
 

--- a/fixit/common/tests/test_insert_suppressions.py
+++ b/fixit/common/tests/test_insert_suppressions.py
@@ -5,12 +5,12 @@
 
 from typing import Iterable
 
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 from fixit.common.insert_suppressions import (
+    insert_suppressions,
     SuppressionComment,
     SuppressionCommentKind,
-    insert_suppressions,
 )
 from fixit.common.utils import dedent_with_lstrip
 

--- a/fixit/common/tests/test_line_mapping.py
+++ b/fixit/common/tests/test_line_mapping.py
@@ -7,7 +7,7 @@ import tokenize
 from io import BytesIO
 from typing import Mapping
 
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 from fixit.common.line_mapping import LineMappingInfo
 from fixit.common.utils import dedent_with_lstrip

--- a/fixit/common/tests/test_report.py
+++ b/fixit/common/tests/test_report.py
@@ -8,7 +8,7 @@ import pickle
 from pathlib import Path
 
 import libcst as cst
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 from fixit.common.report import AstLintRuleReport, BaseLintRuleReport, CstLintRuleReport
 

--- a/fixit/common/tests/test_unused_suppressions.py
+++ b/fixit/common/tests/test_unused_suppressions.py
@@ -7,7 +7,7 @@ from typing import Collection, List, Optional, Type
 
 import libcst as cst
 from libcst.metadata import MetadataWrapper
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 from fixit.common.base import CstContext, CstLintRule, LintConfig
 from fixit.common.comments import CommentInfo
@@ -15,10 +15,10 @@ from fixit.common.ignores import IgnoreInfo
 from fixit.common.line_mapping import LineMappingInfo
 from fixit.common.report import CstLintRuleReport
 from fixit.common.unused_suppressions import (
+    _compose_new_comment,
+    RemoveUnusedSuppressionsRule,
     UNUSED_SUPPRESSION_CODES_IN_COMMENT_MESSAGE,
     UNUSED_SUPPRESSION_COMMENT_MESSAGE,
-    RemoveUnusedSuppressionsRule,
-    _compose_new_comment,
 )
 from fixit.common.utils import dedent_with_lstrip
 from fixit.rule_lint_engine import _get_tokens, _visit_cst_rules_with_context

--- a/fixit/common/unused_suppressions.py
+++ b/fixit/common/unused_suppressions.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Collection, List, Sequence, cast
+from typing import cast, Collection, List, Sequence
 
 import libcst as cst
 from libcst.metadata import ParentNodeProvider, PositionProvider

--- a/fixit/common/utils.py
+++ b/fixit/common/utils.py
@@ -12,7 +12,7 @@ import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Dict, List, Optional, Set, Type, Union, cast
+from typing import cast, Dict, List, Optional, Set, Type, Union
 
 import libcst as cst
 from libcst._add_slots import add_slots

--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -7,7 +7,7 @@ import io
 import tokenize
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Collection, List, Optional, Sequence, Type, cast
+from typing import cast, Collection, List, Optional, Sequence, Type
 
 import libcst as cst
 from libcst.metadata import MetadataWrapper

--- a/fixit/rules/await_async_call.py
+++ b/fixit/rules/await_async_call.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Optional, Sequence, Union, cast
+from typing import cast, Dict, Optional, Sequence, Union
 
 import libcst as cst
 import libcst.matchers as m

--- a/fixit/rules/no_namedtuple.py
+++ b/fixit/rules/no_namedtuple.py
@@ -6,7 +6,7 @@
 from typing import List, Optional, Sequence, Tuple
 
 import libcst as cst
-from libcst import MaybeSentinel, ensure_type, parse_expression
+from libcst import ensure_type, MaybeSentinel, parse_expression
 from libcst.metadata import QualifiedName, QualifiedNameProvider, QualifiedNameSource
 
 from fixit import CstLintRule, InvalidTestCase as Invalid, ValidTestCase as Valid

--- a/fixit/rules/use_is_none_on_optional.py
+++ b/fixit/rules/use_is_none_on_optional.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, Optional, Union, cast
+from typing import cast, Dict, List, Optional, Union
 
 import libcst as cst
 import libcst.matchers as m

--- a/fixit/tests/test_rule_lint_engine.py
+++ b/fixit/tests/test_rule_lint_engine.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 
 import libcst as cst
-from libcst.testing.utils import UnitTest, data_provider
+from libcst.testing.utils import data_provider, UnitTest
 
 from fixit import rule_lint_engine
 from fixit.common.base import CstLintRule, LintConfig

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,9 @@
-black>=19.10b0
+black>=21.10b0
 codecov>=2.0.15
 coverage>=4.5.4
 git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
-isort>=4.3.20
+ufmt==1.3
+usort==1.0.0rc1
 jupyter>=1.0.0
 nbsphinx>=0.7.1
 pyre-check==0.9.9; platform_system != "Windows"

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     flake8 {posargs}
-    isort --check-only {posargs:.}
-    black --check {posargs:.}
+    ufmt check {posargs:.}
     python -m fixit.cli.run_rules {posargs:fixit}
 
 [testenv:docs]
@@ -30,8 +29,7 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    isort -q {posargs:.}
-    black {posargs:.}
+    ufmt format {posargs:.}
     python -m fixit.cli.apply_fix {posargs:.}
 
 [testenv:coverage]


### PR DESCRIPTION
Bringing Fixit in sync w/ LibCST.