### PR TITLE
Fix patched_source type hint and bug related to it

### DIFF
--- a/fixit/cli/apply_fix.py
+++ b/fixit/cli/apply_fix.py
@@ -143,7 +143,7 @@ def apply_fix_operation(
                     updated_source = invoke_formatter(
                         get_lint_config().formatter, updated_source
                     )
-                with open(path, "w") as f:
+                with open(path, "wb") as f:
                     f.write(updated_source)
         else:
             lint_result = get_one_patchable_report_for_path(
@@ -159,7 +159,7 @@ def apply_fix_operation(
             updated_source = lint_result.patched_source
             if updated_source != source:
                 # We don't do any formatting here as it's wasteful. The caller should handle formatting all files at the end.
-                with open(path, "w") as f:
+                with open(path, "wb") as f:
                     f.write(updated_source)
 
                 patched_files_list.append(str(path))

--- a/fixit/rule_lint_engine.py
+++ b/fixit/rule_lint_engine.py
@@ -147,7 +147,7 @@ def lint_file(
 @dataclass(frozen=True)
 class LintRuleReportsWithAppliedPatches:
     reports: Collection[BaseLintRuleReport]
-    patched_source: str
+    patched_source: bytes
 
 
 def lint_file_and_apply_patches(


### PR DESCRIPTION
## Summary

Fixes a bug that caused apply_fix to write to a file in text mode rather than bytes mode even though it's trying to write bytes back.

## Test Plan

Run this in the root of the cloned repository of Fixit:
```
python -m venv .venv
.venv\Scripts\activate.bat
python -m pip install .
python -m fixit.cli.apply_fix
```
If using Linux/macOS, `. .venv/bin/activate` is needed for venv activation instead.