### PR TITLE
Use jinja2<3.1 to fix docs build issue

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ black>=21.10b0
 codecov>=2.0.15
 coverage>=4.5.4
 git+https://github.com/jimmylai/sphinx.git@slots_type_annotation
+jinja2<3.1
 ufmt==1.3
 usort==1.0.0rc1
 jupyter>=1.0.0


### PR DESCRIPTION
## Summary

Fixes an incompatibility of the currently used Sphinx version with Jinja2 3.1. Simple fix until this project is ready to move to a newer version of Sphinx that supports Jinja2 3.1.

## Test Plan

Run `tox -e docs` in a clean environment (so without a `.tox` folder in the project's root directory)