### PR TITLE
Config loading and hierarchical merging

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,6 +14,7 @@ format:
 .PHONY: test
 test:
 	hatch run test
+	hatch run typecheck
 
 .PHONY: lint
 lint:

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -7,6 +7,7 @@ import importlib
 import inspect
 import logging
 import pkgutil
+import sys
 from pathlib import Path
 from typing import Any, Collection, Dict, Iterable, List, Optional
 
@@ -14,9 +15,9 @@ from fixit.rule import LintRule
 
 from .types import Config, RawConfig
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib
-except ImportError:
+else:
     import tomli as tomllib
 
 log = logging.getLogger(__name__)
@@ -89,9 +90,9 @@ def locate_configs(path: Path, root: Optional[Path] = None) -> List[Path]:
     Walking upward from target path, creates a list of candidate paths that exist
     on disk, ordered from nearest/highest priority to further/lowest priority.
 
-    If root is given, only return configs between path and root, ignoring any paths
-    outside of root, even if they would contain relevant configs. If given, root must
-    contain path.
+    If root is given, only return configs between path and root (inclusive), ignoring
+    any paths outside of root, even if they would contain relevant configs.
+    If given, root must contain path.
 
     Returns a list of config paths in priority order, from highest priority to lowest.
     """
@@ -100,7 +101,7 @@ def locate_configs(path: Path, root: Optional[Path] = None) -> List[Path]:
     if not path.is_dir():
         path = path.parent
 
-    root = root.resolve() if root is not None else path.root
+    root = root.resolve() if root is not None else Path(path.anchor)
     path.relative_to(root)  # enforce path being inside root
 
     while True:

--- a/src/fixit/tests/__init__.py
+++ b/src/fixit/tests/__init__.py
@@ -3,4 +3,5 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .config import ConfigTest
 from .smoke import SmokeTest

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from .. import config
+
+
+class ConfigTest(TestCase):
+    def setUp(self):
+        self.td = TemporaryDirectory()
+        self.tdp = Path(self.td.name).resolve()
+
+        self.outer = self.tdp / "outer"
+        self.inner = self.tdp / "outer" / "inner"
+        self.inner.mkdir(parents=True)
+
+        (self.tdp / "pyproject.toml").write_text("[tool.fixit]\nroot = true\n")
+        (self.outer / "fixit.toml").write_text("[tool.fixit]\n")
+        (self.inner / "pyproject.toml").write_text("[tool.fuzzball]\n")
+        (self.inner / "fixit.toml").write_text("[tool.fixit]\nroot = true\n")
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def test_locate_configs(self):
+        for name, path, root, expected in (
+            ("top", self.tdp, None, [self.tdp / "pyproject.toml"]),
+            ("top file", self.tdp / "hello.py", None, [self.tdp / "pyproject.toml"]),
+            (
+                "outer",
+                self.outer,
+                None,
+                [self.outer / "fixit.toml", self.tdp / "pyproject.toml"],
+            ),
+            (
+                "outer file",
+                self.outer / "frob.py",
+                None,
+                [self.outer / "fixit.toml", self.tdp / "pyproject.toml"],
+            ),
+            (
+                "inner",
+                self.inner,
+                None,
+                [
+                    self.inner / "fixit.toml",
+                    self.inner / "pyproject.toml",
+                    self.outer / "fixit.toml",
+                    self.tdp / "pyproject.toml",
+                ],
+            ),
+            (
+                "inner file",
+                self.inner / "test.py",
+                None,
+                [
+                    self.inner / "fixit.toml",
+                    self.inner / "pyproject.toml",
+                    self.outer / "fixit.toml",
+                    self.tdp / "pyproject.toml",
+                ],
+            ),
+            ("outer from outer", self.outer, self.outer, [self.outer / "fixit.toml"]),
+            (
+                "inner from outer",
+                self.inner,
+                self.outer,
+                [
+                    self.inner / "fixit.toml",
+                    self.inner / "pyproject.toml",
+                    self.outer / "fixit.toml",
+                ],
+            ),
+            (
+                "inner from inner",
+                self.inner,
+                self.inner,
+                [self.inner / "fixit.toml", self.inner / "pyproject.toml"],
+            ),
+        ):
+            with self.subTest(name):
+                actual = config.locate_configs(path, root)
+                self.assertListEqual(expected, actual)

--- a/src/fixit/types.py
+++ b/src/fixit/types.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from libcst._add_slots import add_slots
 from libcst.metadata import CodeRange
@@ -32,6 +32,12 @@ class Config:
     path: Path
     enable: List[str]
     disable: List[str]
+
+
+@dataclass
+class RawConfig:
+    path: Path
+    data: Dict[str, Any]
 
 
 @add_slots

--- a/src/fixit/types.py
+++ b/src/fixit/types.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -30,8 +30,12 @@ class Config:
     """
 
     path: Path
-    enable: List[str]
-    disable: List[str]
+    root: Path
+
+    enable: List[str] = field(default_factory=lambda: ["fixit.rules"])
+    disable: List[str] = field(default_factory=list)
+
+    greeting: str = "hello"
 
 
 @dataclass


### PR DESCRIPTION
## Summary

First piece of config loading based on the proposal in https://github.com/amyreese/Fixit/tree/config-prototype

- Walks the tree up from a target path to either a config with `root = true` or the top of the drive/filesystem.
- Loads all discovered files using tomllib/tomli.
- Basic priority-based overrides of values from outer configs.

Future work will add support for more intelligent merging of values rather than strict overrides, as well as support for multiple path-based overrides in a single config.

## Test Plan

Tests!