### PR TITLE
Implementation of real configuration loading, merging, and overrides

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1,4 +1,106 @@
 User Guide
 ==========
 
-Coming soon
+Configuration
+-------------
+
+Fixit uses `TOML format <https://toml.io>`_ for configuration, and supports
+hierarchical, cascading configuration. Fixit will read values from both the
+standardized ``pyproject.toml`` file as well as a separate ``fixit.toml`` file,
+with values from the latter taking precendence over the former, and values from
+files "nearer" to those being linted taking precedence over values from files
+"further" away.
+
+When determining the configuration to use for a given path, Fixit will continue
+looking upward in the filesystem until it reaches either the root of the
+filesystem, or a configuration file is found with :attr:`root` set to ``True``.
+Fixit will then read configuration values from each file, from further to
+nearest, and merge or override values as appropriate.
+
+This behavior enables a monorepo to provide a baseline configuration, while
+individual projects can choose to either add to that baseline, or define their
+own root of configuration to ignore any other baseline configs. This also allows
+the inclusion of external or third-party projects to maintain consistent linting
+results, regardless of whether they are being linted externally or within the
+containing monorepo.
+
+
+``[tool.fixit]``
+^^^^^^^^^^^^^^^^
+
+The main configuration table.
+
+.. attribute:: root
+    :type: bool
+    :value: False
+
+    Marks this file as a root of the configuration hierarchy.
+
+    If set to ``True``, Fixit will not visit any files further up the hierarchy.
+
+.. attribute:: enable
+    :type: list[str]
+    :value: []
+
+    List of modules or individual rules to enable when linting files covered
+    by this configuration.
+
+    Overrides disabled rules from any configuration further up the hierarchy.
+
+    If no rules are explicitly enabled, Fixit will enable the ``fixit.rules``
+    module by default.
+
+.. attribute:: disable
+    :type: list[str]
+    :value: []
+
+    List of modules or individual rules to disable when linting files covered
+    by this configuration.
+
+    Overrides enabled rules from this file, as well any configuration files
+    further up the hierarchy.
+
+
+``[tool.fixit.options]``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``options`` table allows setting options for individual lint rules,
+by mapping the fully-qualified rule name to a dictionary of key/value pairs:
+
+.. code-block:: toml
+
+    [tool.fixit.options]
+    "fixit.rules.ExampleRule" = {greeting = "hello world"}
+
+Alternatively, for rules with a large number of options, the rule name can
+be included in the table name for easier usage. Note that the quotes in the
+table name are required for correctly specifying options:
+
+.. code-block:: toml
+
+    [tool.fixit.options."fixit.rules.ExampleRule"]
+    greeting = "hello world"
+    answer = 42
+
+
+``[[tool.fixit.overrides]]``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Overrides provide a mechanism for hierarchical configuration within a single
+configuration file. They are defined as an
+`array of tables <https://toml.io/en/v1.0.0#array-of-tables>`_, with each table
+defining the subpath it applies to, along with any values from the tables above:
+
+.. code-block:: toml
+
+    [[tool.fixit.overrides]]
+    path = "foo/bar"
+    disable = ["fixit.rules.ExampleRule"]
+
+    [[tool.fixit.overrides.options]]
+    # applies to the above override path only
+    "fixit.rules.Story" = {closing = "goodnight moon"}
+
+    [[tool.fixit.overrides]]
+    path = "fizz/buzz"
+    enable = ["plugin.SomethingNeat"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "click >= 8.0",
+    "frozendict >= 2.1.0",
     "libcst >= 0.3.18",
     "tomli >= 2.0; python_version < '3.11'",
     "trailrunner >= 1.2",
@@ -70,7 +71,7 @@ features = ["dev"]
 
 [tool.hatch.envs.default.scripts]
 test = "python -m fixit.tests"
-typecheck = "mypy src/fixit"
+typecheck = "mypy --install-types --non-interactive src/fixit"
 
 [tool.hatch.envs.lint.scripts]
 check = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,4 +90,5 @@ build = [
 ]
 
 [tool.fixit]
-# TODO
+enable = ["fixit.rules"]
+disable = ["fixit.test.foo", "fixit.test.bar"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "click >= 8.0",
-    "frozendict >= 2.1.0",
     "libcst >= 0.3.18",
     "tomli >= 2.0; python_version < '3.11'",
     "trailrunner >= 1.2",

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -4,9 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import traceback
 from pathlib import Path
 from typing import Generator, Iterable, List
-import traceback
 
 import trailrunner
 
@@ -24,8 +24,7 @@ def _make_result(path: Path, violations: Iterable[LintViolation]) -> Iterable[Re
     except Exception as error:
         # TODO: this is not the right place to catch errors
         logger.debug("Exception while linting", exc_info=error)
-        tb = traceback.format_exc()
-        yield Result(path, violation=None, error=error, traceback=tb)
+        yield Result(path, violation=None, error=(error, traceback.format_exc()))
 
 
 def fixit_bytes(
@@ -57,8 +56,7 @@ def fixit_file(
 
     except Exception as error:
         logger.debug("Exception while fixit_file", exc_info=error)
-        tb = traceback.format_exc()
-        yield Result(path, violation=None, error=error, traceback=tb)
+        yield Result(path, violation=None, error=(error, traceback.format_exc()))
 
 
 def fixit_paths(

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -6,6 +6,7 @@
 import logging
 from pathlib import Path
 from typing import Generator, Iterable, List
+import traceback
 
 import trailrunner
 
@@ -23,7 +24,8 @@ def _make_result(path: Path, violations: Iterable[LintViolation]) -> Iterable[Re
     except Exception as error:
         # TODO: this is not the right place to catch errors
         logger.debug("Exception while linting", exc_info=error)
-        yield Result(path, violation=None, error=error)
+        tb = traceback.format_exc()
+        yield Result(path, violation=None, error=error, traceback=tb)
 
 
 def fixit_bytes(
@@ -55,7 +57,8 @@ def fixit_file(
 
     except Exception as error:
         logger.debug("Exception while fixit_file", exc_info=error)
-        yield Result(path, violation=None, error=error)
+        tb = traceback.format_exc()
+        yield Result(path, violation=None, error=error, traceback=tb)
 
 
 def fixit_paths(

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -230,7 +230,9 @@ def merge_configs(
         options: Optional[RuleConfigs] = None,
     ):
         subpath = subpath.resolve()
-        if not path.is_relative_to(subpath):
+        try:
+            path.relative_to(subpath)
+        except ValueError:  # not relative to subpath
             return
 
         for rule in enable:

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 from .rule import LintRule
-from .types import Config, is_sequence, RawConfig, RuleConfigs, RuleConfigTypes
+from .types import Config, is_sequence, RawConfig, RuleOptionsTable, RuleOptionTypes
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -182,7 +182,7 @@ def get_sequence(
 
 def get_options(
     config: RawConfig, key: str, *, data: Optional[Dict[str, Any]] = None
-) -> RuleConfigs:
+) -> RuleOptionsTable:
     if data:
         mapping = data.pop(key, {})
     else:
@@ -193,13 +193,13 @@ def get_options(
             f"{key!r} must be mapping of values, got {type(key)}", config=config
         )
 
-    rule_configs: RuleConfigs = {}
+    rule_configs: RuleOptionsTable = {}
     for rule_name, rule_config in mapping.items():
         rule_configs[rule_name] = {}
         for key, value in rule_config.items():
-            if not isinstance(value, RuleConfigTypes):
+            if not isinstance(value, RuleOptionTypes):
                 raise ConfigError(
-                    f"{key!r} must be one of {RuleConfigTypes}, got {type(value)}",
+                    f"{key!r} must be one of {RuleOptionTypes}, got {type(value)}",
                     config=config,
                 )
 
@@ -220,14 +220,14 @@ def merge_configs(
     enable_rules: Set[str] = set()
     disable_rules: Set[str] = set()
     local_paths: List[Path] = []
-    rule_options: RuleConfigs = {}
+    rule_options: RuleOptionsTable = {}
 
     def process_subpath(
         subpath: Path,
         *,
         enable: Sequence[str] = (),
         disable: Sequence[str] = (),
-        options: Optional[RuleConfigs] = None,
+        options: Optional[RuleOptionsTable] = None,
     ):
         subpath = subpath.resolve()
         try:

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -21,16 +21,8 @@ from typing import (
     Set,
 )
 
-from frozendict import frozendict  # type: ignore[attr-defined]
-
 from .rule import LintRule
-from .types import (
-    Config,
-    is_sequence,
-    RawConfig,
-    RuleConfigs,
-    RuleConfigTypes,
-)
+from .types import Config, is_sequence, RawConfig, RuleConfigs, RuleConfigTypes
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -235,11 +227,10 @@ def merge_configs(
         *,
         enable: Sequence[str] = (),
         disable: Sequence[str] = (),
-        options: RuleConfigs = frozendict(),
+        options: Optional[RuleConfigs] = None,
     ):
         subpath = subpath.resolve()
         if not path.is_relative_to(subpath):
-            print(f"ignoring {subpath}")
             return
 
         for rule in enable:

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -9,11 +9,21 @@ import logging
 import pkgutil
 import sys
 from pathlib import Path
-from typing import Any, Collection, Dict, Iterable, List, Optional
+from typing import (
+    Any,
+    Collection,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+)
 
 from fixit.rule import LintRule
 
-from .types import Config, RawConfig
+from .types import Config, is_sequence, RawConfig, RuleConfig, RuleConfigs
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -21,6 +31,12 @@ else:
     import tomli as tomllib
 
 log = logging.getLogger(__name__)
+
+
+class ConfigError(ValueError):
+    def __init__(self, msg: str, config: RawConfig):
+        super().__init__(msg)
+        self.config = config
 
 
 def collect_rules(
@@ -134,6 +150,7 @@ def read_configs(paths: List[Path]) -> List[RawConfig]:
     configs: List[RawConfig] = []
 
     for path in paths:
+        path = path.resolve()
         content = path.read_text()
         data = tomllib.loads(content)
         fixit_data = data.get("tool", {}).get("fixit", {})
@@ -148,6 +165,22 @@ def read_configs(paths: List[Path]) -> List[RawConfig]:
     return configs
 
 
+def get_sequence(
+    config: RawConfig, key: str, *, data: Optional[Dict[str, Any]] = None
+) -> Sequence[str]:
+    if data:
+        value = data.pop(key, ())
+    else:
+        value = config.data.pop(key, ())
+
+    if not is_sequence(value):
+        raise ConfigError(
+            f"{key!r} must be array of values, got {type(key)}", config=config
+        )
+
+    return value
+
+
 def merge_configs(
     path: Path, raw_configs: List[RawConfig], root: Optional[Path] = None
 ) -> Config:
@@ -156,26 +189,72 @@ def merge_configs(
 
     Assumes raw_configs are given in order from highest to lowest priority.
     """
-    kwargs: Dict[str, Any] = {
-        "root": None,
-    }
+
+    enable_rules: Set[str] = set()
+    disable_rules: Set[str] = set()
+    local_paths: List[Path] = []
+    rule_configs: RuleConfigs = {}
+
+    def process_subpath(
+        subpath: Path,
+        *,
+        enable: Sequence[str] = (),
+        disable: Sequence[str] = (),
+    ):
+        subpath = subpath.resolve()
+        if not path.is_relative_to(subpath):
+            print(f"ignoring {subpath}")
+            return
+
+        for rule in enable:
+            if rule.startswith("."):
+                if not local_paths or local_paths[0] != subpath:
+                    local_paths.insert(0, subpath)
+
+            enable_rules.add(rule)
+            disable_rules.discard(rule)
+
+        for rule in disable:
+            enable_rules.discard(rule)
+            disable_rules.add(rule)
 
     for config in reversed(raw_configs):
-        if kwargs["root"] is None:
-            kwargs["root"] = config.path.parent
+        if root is None:
+            root = config.path.parent
 
-        # TODO: more than simple overrides
-        # TODO: validate keys/values
-        for key, value in config.data.items():
-            if key == "root" and value:
-                kwargs["root"] = config.path.parent
-            else:
-                kwargs[key] = value
+        data = config.data
+        if data.pop("root", False):
+            root = config.path.parent
 
-    kwargs["path"] = path
-    kwargs["root"] = kwargs["root"] or Path(path.anchor)
+        enable = get_sequence(config, "enable")
+        disable = get_sequence(config, "disable")
 
-    return Config(**kwargs)
+        process_subpath(config.path.parent, enable=enable, disable=disable)
+
+        for override in get_sequence(config, "overrides"):
+            if not isinstance(override, dict):
+                raise ConfigError("'overrides' requires array of tables", config=config)
+
+            subpath = override.get("path", None)
+            if not subpath:
+                raise ConfigError(
+                    "'overrides' table requires 'path' value", config=config
+                )
+
+            subpath = config.path.parent / subpath
+            enable = get_sequence(config, "enable", data=override)
+            disable = get_sequence(config, "disable", data=override)
+            process_subpath(subpath, enable=enable, disable=disable)
+
+        for key in data.keys():
+            log.warning("unknown configuration option %r", key)
+
+    return Config(
+        path=path,
+        root=root or Path(path.anchor),
+        enable=sorted(enable_rules) or ["fixit.rules"],
+        disable=sorted(disable_rules),
+    )
 
 
 def generate_config(path: Path, root: Optional[Path] = None) -> Config:
@@ -183,6 +262,9 @@ def generate_config(path: Path, root: Optional[Path] = None) -> Config:
     Given a file path, walk upwards looking for and applying cascading configs
     """
     path = path.resolve()
+
+    if root is not None:
+        root = root.resolve()
 
     config_paths = locate_configs(path, root=root)
     raw_configs = read_configs(config_paths)

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -34,6 +34,7 @@ class ConfigTest(TestCase):
                 path = "other"
                 enable = ["other.stuff"]
                 disable = ["main.rules"]
+                options = {"other.stuff.Whatever"={key="value"}}
                 """
             )
         )
@@ -170,6 +171,9 @@ class ConfigTest(TestCase):
                                     "path": "other",
                                     "enable": ["other.stuff"],
                                     "disable": ["main.rules"],
+                                    "options": {
+                                        "other.stuff.Whatever": {"key": "value"}
+                                    },
                                 },
                             ],
                         },
@@ -194,6 +198,9 @@ class ConfigTest(TestCase):
                                     "path": "other",
                                     "enable": ["other.stuff"],
                                     "disable": ["main.rules"],
+                                    "options": {
+                                        "other.stuff.Whatever": {"key": "value"}
+                                    },
                                 },
                             ],
                         },
@@ -215,6 +222,9 @@ class ConfigTest(TestCase):
                                     "path": "other",
                                     "enable": ["other.stuff"],
                                     "disable": ["main.rules"],
+                                    "options": {
+                                        "other.stuff.Whatever": {"key": "value"}
+                                    },
                                 },
                             ],
                         },
@@ -315,6 +325,18 @@ class ConfigTest(TestCase):
                     enable=[".localrules"],
                     disable=["main.rules"],
                 ),
+            ),
+            (
+                "other",
+                self.tdp / "other" / "foo.py",
+                None,
+                Config(
+                    path=self.tdp / "other" / "foo.py",
+                    root=self.tdp,
+                    enable=["more.rules", "other.stuff"],
+                    disable=["main.rules", "main.rules.SomethingSpecific"],
+                    options={"other.stuff.Whatever": {"key": "value"}},
+                )
             ),
             (
                 "root",

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -336,7 +336,7 @@ class ConfigTest(TestCase):
                     enable=["more.rules", "other.stuff"],
                     disable=["main.rules", "main.rules.SomethingSpecific"],
                     options={"other.stuff.Whatever": {"key": "value"}},
-                )
+                ),
             ),
             (
                 "root",

--- a/src/fixit/types.py
+++ b/src/fixit/types.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from libcst._add_slots import add_slots
 from libcst.metadata import CodeRange
@@ -76,5 +76,4 @@ class Result:
 
     path: Path
     violation: Optional[LintViolation]
-    error: Optional[Exception] = None
-    traceback: Optional[str] = None
+    error: Optional[Tuple[Exception, str]] = None

--- a/src/fixit/types.py
+++ b/src/fixit/types.py
@@ -11,9 +11,9 @@ from libcst._add_slots import add_slots
 from libcst.metadata import CodeRange
 
 FileContent = bytes
-RuleConfigTypes = (str, int, float)
-RuleConfig = Dict[str, Union[str, int, float]]
-RuleConfigs = Dict[str, RuleConfig]
+RuleOptionTypes = (str, int, float)
+RuleOptions = Dict[str, Union[str, int, float]]
+RuleOptionsTable = Dict[str, RuleOptions]
 
 
 def is_sequence(value: Any) -> bool:
@@ -41,7 +41,7 @@ class Config:
 
     enable: List[str] = field(default_factory=lambda: ["fixit.rules"])
     disable: List[str] = field(default_factory=list)
-    options: RuleConfigs = field(default_factory=dict)
+    options: RuleOptionsTable = field(default_factory=dict)
 
     local_paths: List[str] = field(default_factory=list)
 

--- a/src/fixit/types.py
+++ b/src/fixit/types.py
@@ -11,6 +11,7 @@ from libcst._add_slots import add_slots
 from libcst.metadata import CodeRange
 
 FileContent = bytes
+RuleConfigTypes = (str, int, float)
 RuleConfig = Dict[str, Union[str, int, float]]
 RuleConfigs = Dict[str, RuleConfig]
 
@@ -40,9 +41,9 @@ class Config:
 
     enable: List[str] = field(default_factory=lambda: ["fixit.rules"])
     disable: List[str] = field(default_factory=list)
+    options: RuleConfigs = field(default_factory=dict)
 
     local_paths: List[str] = field(default_factory=list)
-    rule_configs: RuleConfigs = field(default_factory=dict)
 
     def __post_init__(self):
         self.path = self.path.resolve()

--- a/src/fixit/types.py
+++ b/src/fixit/types.py
@@ -5,12 +5,18 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from libcst._add_slots import add_slots
 from libcst.metadata import CodeRange
 
 FileContent = bytes
+RuleConfig = Dict[str, Union[str, int, float]]
+RuleConfigs = Dict[str, RuleConfig]
+
+
+def is_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes))
 
 
 @dataclass
@@ -35,13 +41,21 @@ class Config:
     enable: List[str] = field(default_factory=lambda: ["fixit.rules"])
     disable: List[str] = field(default_factory=list)
 
-    greeting: str = "hello"
+    local_paths: List[str] = field(default_factory=list)
+    rule_configs: RuleConfigs = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.path = self.path.resolve()
+        self.root = self.root.resolve()
 
 
 @dataclass
 class RawConfig:
     path: Path
     data: Dict[str, Any]
+
+    def __post_init__(self):
+        self.path = self.path.resolve()
 
 
 @add_slots
@@ -62,3 +76,4 @@ class Result:
     path: Path
     violation: Optional[LintViolation]
     error: Optional[Exception] = None
+    traceback: Optional[str] = None


### PR DESCRIPTION
## Summary

- [x] Reads `enable`, `disable`, and `options` values from config files
- [x] Reads `overrides` array of tables for configuring subdirectories
- [x] MVP "merging" of enable/disable rules based on sets with zero intelligence
- [x] Simple last-config-wins merging of options for individual rules
- [x] Basic validation of types, but not super thorough
- [x] Simple test cases for subdirectories, merging, and overrides
- [x] Documentation

## Test Plan

TESTS!!

DOCS!! https://fixit--229.org.readthedocs.build/en/229/guide.html