### PR TITLE
Move dev dependencies into optional extras, fix RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,8 +2,9 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 python:
-  version: 3.7
+  version: 3.8
   install:
-    - requirements: requirements-dev.txt
     - method: pip
       path: .
+      extra_requirements:
+        - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,20 @@ dependencies = [
 dynamic = ["version"]
 description = "A lint framework that writes better Python code for you."
 
+[project.optional-dependencies]
+docs = [
+    "sphinx == 4.3.2",
+    "sphinx-mdinclude == 0.5.2",
+]
+dev = [
+    "black==22.3.0",
+    "flake8==4.0.1",
+    "flake8-bugbear==22.7.1",
+    "mypy == 0.971",
+    "ufmt==1.3.3",
+    "usort==1.0.2",
+]
+
 [project.scripts]
 fixit = "fixit.cli:main"
 
@@ -52,22 +66,14 @@ source = "vcs"
 version-file = "src/fixit/__version__.py"
 
 [tool.hatch.envs.default]
-dependencies = [
-    "mypy==0.971",
-]
+features = ["dev"]
+
 [tool.hatch.envs.default.scripts]
 test = "python -m fixit.tests"
 typecheck = "mypy src/fixit"
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = [
-    "black==22.3.0",
-    "flake8==4.0.1",
-    "flake8-bugbear==22.7.1",
-    "ufmt==1.3.3",
-    "usort==1.0.2",
-]
 [tool.hatch.envs.lint.scripts]
 check = [
     "flake8 src/fixit",
@@ -78,10 +84,7 @@ fix = [
 ]
 
 [tool.hatch.envs.docs]
-dependencies = [
-    "sphinx==4.3.2",
-    "sphinx_mdinclude==0.5.1",
-]
+features = ["docs"]
 [tool.hatch.envs.docs.scripts]
 build = [
     "sphinx-build -a -b html docs html",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,6 @@ features = ["dev"]
 test = "python -m fixit.tests"
 typecheck = "mypy src/fixit"
 
-[tool.hatch.envs.lint]
-detached = true
 [tool.hatch.envs.lint.scripts]
 check = [
     "flake8 src/fixit",


### PR DESCRIPTION
## Summary

- Moves dev dependencies into optional extras
- Configures hatch to install extras for relevant envs
- Configures RTD to use Py3.8 and install docs extras

## Test Plan

CI + RTD