### PR TITLE
fix windows ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          pip install -U pip hatch
+          python -m pip install -U pip hatch
           python -m hatch env create
           python -m hatch env create lint
           python -m hatch env create docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,18 +27,18 @@ jobs:
       - name: Install
         run: |
           pip install -U pip hatch
-          hatch env create
-          hatch env create lint
-          hatch env create docs
+          python -m hatch env create
+          python -m hatch env create lint
+          python -m hatch env create docs
       - name: Test
         run: |
-          hatch run test
+          python -m hatch run test
       - name: Lint
         run: |
-          hatch run lint:check
+          python -m hatch run lint:check
       - name: Typecheck
         run: |
-          hatch run typecheck
+          python -m hatch run typecheck
       - name: Docs
         run: |
-          hatch run docs:build
+          python -m hatch run docs:build


### PR DESCRIPTION
For some reason, `pip` doesn't put installed scripts onto the PATH on Windows GitHub CI