### PR TITLE
Overhaul rule collection and loading

### DIFF
--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -13,6 +13,7 @@ import click
 from fixit import __version__
 
 from .api import fixit_paths
+from .config import collect_rules, generate_config
 from .ftypes import Options
 
 
@@ -70,3 +71,25 @@ def fix(
     lint and autofix one or more files and return results
     """
     ctx.fail("not implemented yet")
+
+
+@main.command()
+@click.pass_context
+@click.argument("paths", nargs=-1, type=click.Path(path_type=Path))
+def debug(ctx: click.Context, paths: Iterable[Path]):
+    """
+    print debug info for each path
+    """
+    try:
+        from rich import print as pprint
+    except ImportError:
+        from pprint import pprint  # type: ignore
+
+    for path in paths:
+        path = path.resolve()
+        config = generate_config(path)
+        rules = collect_rules(config.enable, config.disable)
+
+        pprint(">>> ", path)
+        pprint(config)
+        pprint(rules)

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -3,9 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from libcst._add_slots import add_slots
 from libcst.metadata import CodePosition as CSTCodePosition, CodeRange as CSTCodeRange
@@ -17,9 +18,39 @@ RuleOptionsTable = Dict[str, RuleOptions]
 CodeRange = CSTCodeRange
 CodePosition = CSTCodePosition
 
+QualifiedRuleRegex = re.compile(
+    r"""
+    ^
+    (?P<local>\.)?
+    (?P<module>[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)*)
+    (?::(?P<name>[a-zA-Z0-9_]+))?
+    $
+    """,
+    re.VERBOSE,
+)
+
 
 def is_sequence(value: Any) -> bool:
     return isinstance(value, Sequence) and not isinstance(value, (str, bytes))
+
+
+def is_collection(value: Any) -> bool:
+    return isinstance(value, Iterable) and not isinstance(value, (str, bytes))
+
+
+@dataclass(slots=True, frozen=True, order=True)
+class QualifiedRule:
+    module: str
+    name: Optional[str] = None
+    local: Optional[str] = None
+    root: Optional[Path] = field(default=None, hash=False, compare=False, repr=False)
+
+    def __str__(self) -> str:
+        return (
+            ("." if self.local else "")
+            + self.module
+            + (f":{self.name}" if self.name else "")
+        )
 
 
 @dataclass
@@ -41,11 +72,11 @@ class Config:
     path: Path
     root: Path
 
-    enable: List[str] = field(default_factory=lambda: ["fixit.rules"])
-    disable: List[str] = field(default_factory=list)
+    enable: List[QualifiedRule] = field(
+        default_factory=lambda: [QualifiedRule("fixit.rules")]
+    )
+    disable: List[QualifiedRule] = field(default_factory=list)
     options: RuleOptionsTable = field(default_factory=dict)
-
-    local_paths: List[str] = field(default_factory=list)
 
     def __post_init__(self):
         self.path = self.path.resolve()

--- a/src/fixit/tests/__init__.py
+++ b/src/fixit/tests/__init__.py
@@ -4,13 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 
 from fixit.config import collect_rules
+from fixit.ftypes import QualifiedRule
 
 from fixit.testing import add_lint_rule_tests_to_module
 from .config import ConfigTest
+from .ftypes import TypesTest
 from .rule.cst import RuleTest, RunnerTest
 from .smoke import SmokeTest
 
 add_lint_rule_tests_to_module(
     globals(),
-    collect_rules(enables=["fixit.rules"], disables=[]),
+    collect_rules(enables=[QualifiedRule("fixit.rules")], disables=[]),
 )

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -10,10 +10,12 @@ from textwrap import dedent
 from unittest import TestCase
 
 from .. import config
-from ..ftypes import Config, RawConfig
+from ..ftypes import Config, QualifiedRule, RawConfig
 
 
 class ConfigTest(TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.td = TemporaryDirectory()
         self.tdp = Path(self.td.name).resolve()
@@ -244,7 +246,11 @@ class ConfigTest(TestCase):
             (
                 "empty",
                 [],
-                Config(path=target, root=Path(target.anchor), enable=["fixit.rules"]),
+                Config(
+                    path=target,
+                    root=Path(target.anchor),
+                    enable=[QualifiedRule("fixit.rules")],
+                ),
             ),
             (
                 "single",
@@ -254,7 +260,12 @@ class ConfigTest(TestCase):
                         {"enable": ["foo", "bar"], "disable": ["bar"]},
                     ),
                 ],
-                Config(path=target, root=root, enable=["foo"], disable=["bar"]),
+                Config(
+                    path=target,
+                    root=root,
+                    enable=[QualifiedRule("foo")],
+                    disable=[QualifiedRule("bar")],
+                ),
             ),
             (
                 "without root",
@@ -266,7 +277,11 @@ class ConfigTest(TestCase):
                     ),
                     RawConfig((root / "a/fixit.toml"), {"enable": ["foo"]}),
                 ],
-                Config(path=target, root=(root / "a"), enable=["bar", "foo"]),
+                Config(
+                    path=target,
+                    root=(root / "a"),
+                    enable=[QualifiedRule("bar"), QualifiedRule("foo")],
+                ),
             ),
             (
                 "with root",
@@ -284,7 +299,9 @@ class ConfigTest(TestCase):
                         {},
                     ),
                 ],
-                Config(path=target, root=(root / "a/b/c"), enable=["foo"]),
+                Config(
+                    path=target, root=(root / "a/b/c"), enable=[QualifiedRule("foo")]
+                ),
             ),
         ):
             with self.subTest(name):
@@ -300,8 +317,8 @@ class ConfigTest(TestCase):
                 Config(
                     path=self.inner / "foo.py",
                     root=self.inner,
-                    enable=["fake8", "make8"],
-                    disable=["foo.bar"],
+                    enable=[QualifiedRule("fake8"), QualifiedRule("make8")],
+                    disable=[QualifiedRule("foo.bar")],
                 ),
             ),
             (
@@ -311,8 +328,14 @@ class ConfigTest(TestCase):
                 Config(
                     path=self.outer / "foo.py",
                     root=self.tdp,
-                    enable=[".localrules", "more.rules"],
-                    disable=["main.rules", "main.rules.SomethingSpecific"],
+                    enable=[
+                        QualifiedRule("localrules", local=".", root=self.outer),
+                        QualifiedRule("more.rules"),
+                    ],
+                    disable=[
+                        QualifiedRule("main.rules"),
+                        QualifiedRule("main.rules.SomethingSpecific"),
+                    ],
                 ),
             ),
             (
@@ -322,8 +345,8 @@ class ConfigTest(TestCase):
                 Config(
                     path=self.outer / "foo.py",
                     root=self.outer,
-                    enable=[".localrules"],
-                    disable=["main.rules"],
+                    enable=[QualifiedRule("localrules", local=".", root=self.outer)],
+                    disable=[QualifiedRule("main.rules")],
                 ),
             ),
             (
@@ -333,8 +356,11 @@ class ConfigTest(TestCase):
                 Config(
                     path=self.tdp / "other" / "foo.py",
                     root=self.tdp,
-                    enable=["more.rules", "other.stuff"],
-                    disable=["main.rules", "main.rules.SomethingSpecific"],
+                    enable=[QualifiedRule("more.rules"), QualifiedRule("other.stuff")],
+                    disable=[
+                        QualifiedRule("main.rules"),
+                        QualifiedRule("main.rules.SomethingSpecific"),
+                    ],
                     options={"other.stuff.Whatever": {"key": "value"}},
                 ),
             ),
@@ -345,8 +371,8 @@ class ConfigTest(TestCase):
                 Config(
                     path=self.tdp / "foo.py",
                     root=self.tdp,
-                    enable=["main.rules", "more.rules"],
-                    disable=["main.rules.SomethingSpecific"],
+                    enable=[QualifiedRule("main.rules"), QualifiedRule("more.rules")],
+                    disable=[QualifiedRule("main.rules.SomethingSpecific")],
                 ),
             ),
         ):

--- a/src/fixit/tests/ftypes.py
+++ b/src/fixit/tests/ftypes.py
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Set
+from unittest import TestCase
+
+from .. import ftypes
+
+
+class TypesTest(TestCase):
+    def test_qualified_rule(self):
+        valid: Set[ftypes.QualifiedRule] = set()
+
+        for value, expected in (
+            ("", None),
+            ("foo-bar", None),
+            ("foo/bar", None),
+            ("foo", {"local": None, "module": "foo", "name": None}),
+            ("foo.bar", {"local": None, "module": "foo.bar", "name": None}),
+            ("foo.bar:Baz", {"local": None, "module": "foo.bar", "name": "Baz"}),
+            (".foo", {"local": ".", "module": "foo", "name": None}),
+            (".foo.bar", {"local": ".", "module": "foo.bar", "name": None}),
+            (".foo.bar:Baz", {"local": ".", "module": "foo.bar", "name": "Baz"}),
+            ("..foo", None),
+        ):
+            with self.subTest(value):
+                match = ftypes.QualifiedRuleRegex.match(value)
+                if expected is not None:
+                    self.assertIsNotNone(match, f"{value!r} should match QualifiedRule")
+                    self.assertEqual(expected, match.groupdict())
+
+                    rule = ftypes.QualifiedRule(**match.groupdict())
+                    self.assertEqual(expected["local"], rule.local)
+                    self.assertEqual(expected["module"], rule.module)
+                    self.assertEqual(expected["name"], rule.name)
+
+                    valid.add(rule)
+
+                else:
+                    self.assertIsNone(
+                        match, f"{value!r} should not match QualifiedRule"
+                    )
+
+        self.assertSetEqual(
+            {
+                ftypes.QualifiedRule("foo"),
+                ftypes.QualifiedRule("foo.bar"),
+                ftypes.QualifiedRule("foo.bar", "Baz"),
+                ftypes.QualifiedRule("foo", local="."),
+                ftypes.QualifiedRule("foo.bar", local="."),
+                ftypes.QualifiedRule("foo.bar", "Baz", local="."),
+            },
+            valid,
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #252
* #251
* #250
* #249
* #245
* __->__ #244

- Creates new QualifiedRule class to hold module/name/local info from
  enabled or disabled rules in config
- Simplifies rule collection to always try importing the full module
  directly, including all modules if given a package name, and then
  pulls the name out after everything is loaded.
- Materializes full enable/disable rule sets, then subtracts disabled
  sets from enabled sets to get final rules to apply.
- Enables pulling in rules from other packages from `__init__`
- Enables defining and referencing predefined sets of rules, eg,
  `fixit.rules:core`, and materializing from those sets during rule
  collection.
- Skips recursing into subpackages; will document later.
- Skips handling local modules/rules; will implement later.
- Adds `debug` CLI command to dump final config and filtered rule set
  for one or more given paths, using rich for pretty print if available.