### PR TITLE
Implement local rule loading

### DIFF
--- a/src/fixit/local/__init__.py
+++ b/src/fixit/local/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Fake package to serve as module root when loading local rules


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #252
* #251
* __->__ #250
* #249
* #245
* #244

- Refactors module collection and walking into top level functions
- Adds new helper context manager to allow importing arbitrary local
  rules as if they were in the `fixit.local` namespace
- Imports local rules directly from qualified namespace