### PR TITLE
Add pre-commit hooks configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,12 @@
+- id: fixit-lint
+  name: Fixit - lint
+  description: This hook shows Fixit lints and suggested changes without applying autofixes.
+  entry: fixit lint
+  language: python
+  types: [python]
+- id: fixit-fix
+  name: Fixit - lint and apply autofixes
+  description: This hook shows Fixit lints and applies suggested changes.
+  entry: fixit fix
+  language: python
+  types: [python]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Fixit: advanced linting framework
     :maxdepth: 2
 
     guide
+    integrations
     api
 
 .. toctree::

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -1,8 +1,8 @@
 Integrations
 ============
 
-Version control integration (pre-commit)
-----------------------------------------
+pre-commit
+----------
 
 Fixit can be included as a hook for `pre-commit <https://pre-commit.com>`__.
 

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -1,0 +1,31 @@
+Integrations
+============
+
+Version control integration (pre-commit)
+----------------------------------------
+
+Fixit can be included as a hook for `pre-commit <https://pre-commit.com>`__.
+
+Once you `install it <https://pre-commit.com/#installation>`__, you can add Fixit's pre-commit hook to the ``.pre-commit-config.yaml`` file in your repository.
+
+- To run lint rules on commit, add:
+
+.. code:: yaml
+
+    repos:
+      - repo: https://github.com/Instagram/Fixit
+        rev: 0.0.0  # replace with the Fixit version to use
+        hooks:
+          - id: fixit-lint
+
+- To run lint rules and apply autofixes, add:
+
+.. code:: yaml
+
+    repos:
+      - repo: https://github.com/Instagram/Fixit
+        rev: 0.0.0  # replace with the Fixit version to use
+        hooks:
+          - id: fixit-fix
+
+To read more about how you can customize your pre-commit configuration, see the `pre-commit docs <https://pre-commit.com/#pre-commit-configyaml---hooks>`__.


### PR DESCRIPTION
## Summary

Supersedes #218, fixes #193
Since I'm not very familiar with how this tool works, I am unsure whether it is safe to run multiple Fixit processes (which is what pre-commit does by default by splitting out passed file names evenly) in parallel or if Fixit should be passed with all files at once. If it can cause some issues, I can add [`require_serial` option](https://pre-commit.com/#hooks-require_serial).

I added a new document for integrations as it seems like a good place to also document editor integrations (or perhaps CI integrations) in the future and I felt that the user guide would probably become too crowded in the future to use for documentation anyway.

## Test Plan

1. Install pre-commit using:
```
python -m pip install pre-commit
```
2. Create a repository with a lint rule and autofixer to test on (I'm not familiar with this tool so I can't really give a specific example, I assume a reviewer will be able to come up with one)
3. Run pre-commit on all files to test the behavior of the hook:
```
pre-commit run --all-files
```
