### PR TITLE
Formatting the linting output

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,7 @@ Simple API
 
 .. autofunction:: fixit_paths
 .. autofunction:: fixit_file
+.. autofunction:: print_result
 
 .. autoclass:: Result
 

--- a/src/fixit/__init__.py
+++ b/src/fixit/__init__.py
@@ -9,7 +9,7 @@ Linting framework built on LibCST, with automatic fixes
 
 __version__ = "0.2.0"
 
-from .api import fixit_bytes, fixit_file, fixit_paths
+from .api import fixit_bytes, fixit_file, fixit_paths, print_result
 from .ftypes import CodePosition, CodeRange, Config, FileContent, Result
 from .rule import LintRule
 from .rule.cst import CSTLintRule, CstLintRule
@@ -20,6 +20,7 @@ __all__ = [
     "fixit_bytes",
     "fixit_file",
     "fixit_paths",
+    "print_result",
     "LintRule",
     "CSTLintRule",
     "CstLintRule",

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -19,7 +19,10 @@ from .ftypes import Config, FileContent, LintViolation, Result
 logger = logging.getLogger(__name__)
 
 
-def print_result(result: Result, debug: bool) -> None:
+def print_result(result: Result, debug: bool = False) -> None:
+    """
+    Print linting results in a clear format for easy understanding
+    """
     path = result.path
     if result.violation:
         rule_name = result.violation.rule_name
@@ -29,15 +32,13 @@ def print_result(result: Result, debug: bool) -> None:
         click.secho(
             f"{path}@{start_line}:{start_col} {rule_name}: {message}", fg="yellow"
         )
-    else:
+    elif result.error:
         # An exception occurred while processing a file
-        if result.error:
-            error = result.error[0]
-            traceback_info = result.error[1]
-            if debug:
-                click.secho(f"{error}: {traceback_info}", fg="red")
-            else:
-                click.secho(f"{error}", fg="red")
+        error, tb = result.error
+        if debug:
+            click.secho(f"{error}: {tb}", fg="red")
+        else:
+            click.secho(f"{error}", fg="red")
 
 
 def _make_result(path: Path, violations: Iterable[LintViolation]) -> Iterable[Result]:

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -8,6 +8,8 @@ import traceback
 from pathlib import Path
 from typing import Generator, Iterable, List
 
+import click
+
 import trailrunner
 
 from .config import collect_rules, generate_config
@@ -15,6 +17,27 @@ from .engine import collect_violations
 from .ftypes import Config, FileContent, LintViolation, Result
 
 logger = logging.getLogger(__name__)
+
+
+def print_result(result: Result, debug: bool) -> None:
+    path = result.path
+    if result.violation:
+        rule_name = result.violation.rule_name
+        start_line = result.violation.range.start.line
+        start_col = result.violation.range.start.column
+        message = result.violation.message
+        click.secho(
+            f"{path}@{start_line}:{start_col} {rule_name}: {message}", fg="yellow"
+        )
+    else:
+        # An exception occurred while processing a file
+        if result.error:
+            error = result.error[0]
+            traceback_info = result.error[1]
+            if debug:
+                click.secho(f"{error}: {traceback_info}", fg="red")
+            else:
+                click.secho(f"{error}", fg="red")
 
 
 def _make_result(path: Path, violations: Iterable[LintViolation]) -> Iterable[Result]:

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -57,7 +57,7 @@ def lint(
     lint one or more paths and return suggestions
     """
     for result in fixit_paths(paths):
-        print(result)
+        click.secho(result, fg="red")
 
 
 @main.command()

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -12,7 +12,7 @@ import click
 
 from fixit import __version__
 
-from .api import fixit_paths
+from .api import fixit_paths, print_result
 from .config import collect_rules, generate_config
 from .ftypes import Options
 
@@ -57,7 +57,7 @@ def lint(
     lint one or more paths and return suggestions
     """
     for result in fixit_paths(paths):
-        click.secho(result, fg="red")
+        print_result(result, ctx.obj.debug)
 
 
 @main.command()

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -115,3 +115,13 @@ class Result:
     path: Path
     violation: Optional[LintViolation]
     error: Optional[Tuple[Exception, str]] = None
+
+    def __str__(self):
+        if self.violation:
+            rule_name = self.violation.rule_name
+            start_line = self.violation.range.start.line
+            start_col = self.violation.range.start.column
+            message = self.violation.message
+        else:
+            rule_name, start_line, start_col, message = None, None, None, None
+        return f"{self.path}@{start_line}:{start_col} {rule_name}: {message}"

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -115,13 +115,3 @@ class Result:
     path: Path
     violation: Optional[LintViolation]
     error: Optional[Tuple[Exception, str]] = None
-
-    def __str__(self):
-        if self.violation:
-            rule_name = self.violation.rule_name
-            start_line = self.violation.range.start.line
-            start_col = self.violation.range.start.column
-            message = self.violation.message
-        else:
-            rule_name, start_line, start_col, message = None, None, None, None
-        return f"{self.path}@{start_line}:{start_col} {rule_name}: {message}"


### PR DESCRIPTION
## Summary
Currently, Fixit just dumps objects to stdout. This pull request changes the output  to this format: `<filepath>@<line>:<col> <rulename>: <summary>`. It also colors the output in red. 


## Test Plan
`make test lint html` should give no errors. 
Run `hatch env run -- fixit lint .` in the Fixit root directory, the new output format is as follows:
<img width="1132" alt="Screenshot 2023-02-07 at 4 05 12 PM" src="https://user-images.githubusercontent.com/19936324/217395061-1c62c3d8-636d-448a-9b3d-8e9ec7e6d97a.png">
