### PR TITLE
Enable FullRepoManager when lint rules need it

### DIFF
--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -61,7 +61,7 @@ def fixit_bytes(
     Lint raw bytes content representing a single path, using the given configuration.
     """
     rules = collect_rules(config.enable, config.disable)
-    yield from _make_result(path, collect_violations(content, rules))
+    yield from _make_result(path, collect_violations(content, rules, config))
 
 
 def fixit_file(

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -4,15 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Collection, Dict, Iterable, List, Type
 
-from .ftypes import FileContent, LintViolation
+from .ftypes import FileContent, LintViolation, Config
 
 from .rule import LintRule, LintRunner
 
 
 def collect_violations(
-    source: FileContent, rules: Collection[LintRule]
+    source: FileContent, rules: Collection[LintRule], config: Config
 ) -> Iterable[LintViolation]:
     # partition rules by LintRunner:
     rules_by_runner: Dict[Type[LintRunner], List[LintRule]] = defaultdict(lambda: [])
@@ -21,4 +22,4 @@ def collect_violations(
 
     for runner_cls, rules in rules_by_runner.items():
         runner = runner_cls()
-        yield from runner.collect_violations(source, rules)
+        yield from runner.collect_violations(source, rules, config)

--- a/src/fixit/rule/__init__.py
+++ b/src/fixit/rule/__init__.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
-
 from dataclasses import dataclass
-
+from pathlib import Path
 from typing import (
     Callable,
     ClassVar,
@@ -25,7 +24,7 @@ from typing import (
     Union,
 )
 
-from fixit.ftypes import CodeRange, FileContent, LintViolation
+from fixit.ftypes import CodeRange, FileContent, LintViolation, Config
 
 
 Timings = Dict[str, int]
@@ -70,6 +69,7 @@ class LintRunner(ABC, Generic[SomeRule]):
         self,
         source: FileContent,
         rules: Collection[SomeRule],
+        config: Config,
         timings_hook: Optional[TimingsHook] = None,
     ) -> Iterable[LintViolation]:
         pass

--- a/src/fixit/rule/cst.py
+++ b/src/fixit/rule/cst.py
@@ -17,6 +17,7 @@ from typing import (
     Iterator,
     Mapping,
     Optional,
+    Set,
     Union,
 )
 
@@ -30,12 +31,14 @@ from libcst import (
 from libcst.metadata import (
     CodePosition,
     CodeRange,
+    FullRepoManager,
+    FullyQualifiedNameProvider,
     MetadataWrapper,
     PositionProvider,
     ProviderT,
 )
 
-from fixit.ftypes import FileContent, LintViolation
+from fixit.ftypes import Config, FileContent, LintViolation
 from . import LintRule, LintRunner, TimingsHook
 
 
@@ -50,6 +53,7 @@ class CSTLintRunner(LintRunner["CSTLintRule"]):
         self,
         source: FileContent,
         rules: Collection["CSTLintRule"],
+        config: Config,
         timings_hook: Optional[TimingsHook] = None,
     ) -> Iterable[LintViolation]:
         """Run multiple `CSTLintRule`s and yield any lint violations.
@@ -69,10 +73,27 @@ class CSTLintRunner(LintRunner["CSTLintRule"]):
                 logger.debug(f"PERF: {name} took {duration_us} µs")
                 self.timings[name] += duration_us
 
+        metadata_cache: Optional[Mapping[ProviderT, object]] = None
+        needs_repo_manager: Set[ProviderT] = set()
+
         for rule in rules:
             rule._visit_hook = visit_hook
+            if FullyQualifiedNameProvider in rule.METADATA_DEPENDENCIES:
+                needs_repo_manager.add(FullyQualifiedNameProvider)
 
-        mod = MetadataWrapper(parse_module(source), unsafe_skip_copy=True)
+        if needs_repo_manager:
+            repo_manager = FullRepoManager(
+                repo_root_dir=config.root.as_posix(),
+                paths=[config.path.as_posix()],
+                providers={FullyQualifiedNameProvider},
+            )
+            repo_manager.resolve_cache()
+            metadata_cache = repo_manager.get_cache_for_path(config.path.as_posix())
+
+        print(f"{metadata_cache = !r}")
+        mod = MetadataWrapper(
+            parse_module(source), unsafe_skip_copy=True, cache=metadata_cache
+        )
         mod.visit_batched(rules)
         for rule in rules:
             for violation in rule._violations:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Looks at the list of enable lint rules, and if any of those need the
`FullyQualifiedNameProvider` metadata, and then enables the
`FullRepoManager` from libcst. The cache is then resolved and passed
through the metadata wrapper when visiting the CST, enabling rules to
use the appropriate metadata.

Requires passing the root path and file path being linted to
`FullRepoManager`, which is accomplished by passing the Fixit config
further through the API into the `CSTLintRunner` implementation.