### PR TITLE
Pass file path to libcst when parsing module

### DIFF
--- a/src/fixit/rule/cst.py
+++ b/src/fixit/rule/cst.py
@@ -93,7 +93,9 @@ class CSTLintRunner(LintRunner["CSTLintRule"]):
             metadata_cache = repo_manager.get_cache_for_path(config.path.as_posix())
 
         mod = MetadataWrapper(
-            parse_module(source), unsafe_skip_copy=True, cache=metadata_cache
+            parse_module(source, path=config.path),
+            unsafe_skip_copy=True,
+            cache=metadata_cache,
         )
         mod.visit_batched(rules)
         for rule in rules:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #269

This supplies the necessary path information that will allow lint rules
to discover the file path currently being linted by looking for the
`.path` attribute on the CST root `Module` node.

Depends on changes in Instagram/LibCST#887