### PR TITLE
Support .fixit.toml for configs as well

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -6,10 +6,10 @@ Configuration
 
 Fixit uses `TOML format <https://toml.io>`_ for configuration, and supports
 hierarchical, cascading configuration. Fixit will read values from both the
-standardized ``pyproject.toml`` file as well as a separate ``fixit.toml`` file,
-with values from the latter taking precendence over the former, and values from
-files "nearer" to those being linted taking precedence over values from files
-"further" away.
+standardized ``pyproject.toml`` file as well as a separate ``.fixit.toml`` or
+``fixit.toml`` file, with values from the latter taking precendence over the
+former, and values from files "nearer" to those being linted taking precedence
+over values from files "further" away.
 
 When determining the configuration to use for a given path, Fixit will continue
 looking upward in the filesystem until it reaches either the root of the

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -45,6 +45,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+FIXIT_CONFIG_FILENAMES = ("fixit.toml", ".fixit.toml", "pyproject.toml")
 FIXIT_LOCAL_MODULE = "fixit.local"
 
 log = logging.getLogger(__name__)
@@ -230,11 +231,7 @@ def locate_configs(path: Path, root: Optional[Path] = None) -> List[Path]:
     path.relative_to(root)  # enforce path being inside root
 
     while True:
-        candidates = (
-            path / "fixit.toml",
-            path / "pyproject.toml",
-        )
-
+        candidates = (path / filename for filename in FIXIT_CONFIG_FILENAMES)
         for candidate in candidates:
             if candidate.is_file():
                 results.append(candidate)

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -40,7 +40,7 @@ class ConfigTest(TestCase):
                 """
             )
         )
-        (self.outer / "fixit.toml").write_text(
+        (self.outer / ".fixit.toml").write_text(
             dedent(
                 """
                 [tool.fixit]
@@ -80,13 +80,13 @@ class ConfigTest(TestCase):
                 "outer",
                 self.outer,
                 None,
-                [self.outer / "fixit.toml", self.tdp / "pyproject.toml"],
+                [self.outer / ".fixit.toml", self.tdp / "pyproject.toml"],
             ),
             (
                 "outer file",
                 self.outer / "frob.py",
                 None,
-                [self.outer / "fixit.toml", self.tdp / "pyproject.toml"],
+                [self.outer / ".fixit.toml", self.tdp / "pyproject.toml"],
             ),
             (
                 "inner",
@@ -95,7 +95,7 @@ class ConfigTest(TestCase):
                 [
                     self.inner / "fixit.toml",
                     self.inner / "pyproject.toml",
-                    self.outer / "fixit.toml",
+                    self.outer / ".fixit.toml",
                     self.tdp / "pyproject.toml",
                 ],
             ),
@@ -106,11 +106,11 @@ class ConfigTest(TestCase):
                 [
                     self.inner / "fixit.toml",
                     self.inner / "pyproject.toml",
-                    self.outer / "fixit.toml",
+                    self.outer / ".fixit.toml",
                     self.tdp / "pyproject.toml",
                 ],
             ),
-            ("outer from outer", self.outer, self.outer, [self.outer / "fixit.toml"]),
+            ("outer from outer", self.outer, self.outer, [self.outer / ".fixit.toml"]),
             (
                 "inner from outer",
                 self.inner,
@@ -118,7 +118,7 @@ class ConfigTest(TestCase):
                 [
                     self.inner / "fixit.toml",
                     self.inner / "pyproject.toml",
-                    self.outer / "fixit.toml",
+                    self.outer / ".fixit.toml",
                 ],
             ),
             (
@@ -136,7 +136,7 @@ class ConfigTest(TestCase):
         # in-out priority order
         innerA = self.inner / "fixit.toml"
         innerB = self.inner / "pyproject.toml"
-        outer = self.outer / "fixit.toml"
+        outer = self.outer / ".fixit.toml"
         top = self.tdp / "pyproject.toml"
 
         for name, paths, expected in (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #278

For projects or repos that prefer to have configuration files prefixed
with a dot, this allows those projects to use a `.fixit.toml` filename
to match options from flake8, mypy, etc.

This specifically puts `.fixit.toml` as lower precedence than
`fixit.toml`, but higher precedence than `pyproject.toml`.