### PR TITLE
Basic multiprocessing when linting multiple files

### DIFF
--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -83,6 +83,14 @@ def fixit_file(
         yield Result(path, violation=None, error=(error, traceback.format_exc()))
 
 
+def _fixit_file_wrapper(path: Path) -> List[Result]:
+    """
+    Wrapper because generators can't be pickled or used directly via multiprocessing
+    TODO: replace this with some sort of queue or whatever
+    """
+    return list(fixit_file(path))
+
+
 def fixit_paths(
     paths: Iterable[Path],
 ) -> Generator[Result, None, None]:
@@ -96,5 +104,8 @@ def fixit_paths(
     for path in paths:
         expanded_paths.extend(trailrunner.walk(path))
 
-    for path in expanded_paths:
-        yield from fixit_file(path)
+    if len(expanded_paths) == 1:
+        yield from fixit_file(expanded_paths[0])
+    else:
+        for path, results in trailrunner.run_iter(expanded_paths, _fixit_file_wrapper):
+            yield from results

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -107,5 +107,5 @@ def fixit_paths(
     if len(expanded_paths) == 1:
         yield from fixit_file(expanded_paths[0])
     else:
-        for path, results in trailrunner.run_iter(expanded_paths, _fixit_file_wrapper):
+        for _, results in trailrunner.run_iter(expanded_paths, _fixit_file_wrapper):
             yield from results

--- a/src/fixit/tests/smoke.py
+++ b/src/fixit/tests/smoke.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from pathlib import Path
 from unittest import TestCase
 
 from click.testing import CliRunner
@@ -20,6 +21,12 @@ class SmokeTest(TestCase):
         self.assertRegex(result.stdout, rf"fixit, version {__version__}")
 
     def test_this_file_is_clean(self) -> None:
-        result = self.runner.invoke(main, ["lint", __file__])
+        result = self.runner.invoke(main, ["lint", __file__], catch_exceptions=False)
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_this_project_is_clean(self) -> None:
+        project_dir = Path(__file__).parent.parent.as_posix()
+        result = self.runner.invoke(main, ["lint", project_dir], catch_exceptions=False)
         self.assertEqual(result.output, "")
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #281
* __->__ #279

Enables simple concurrency when linting multiple files using the
multiprocessing implementation from trailrunner. Each file will be
linted in its own child process, reducing runtime against the fixit
codebase by approximately 60%.

Future performance improvements to consider would focus around
classifying fast/slow rules, and running slower rules as separate jobs.