### PR TITLE
Return non-zero exit codes for violations/errors

### DIFF
--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -36,9 +36,9 @@ def print_result(result: Result, debug: bool = False) -> None:
         # An exception occurred while processing a file
         error, tb = result.error
         if debug:
-            click.secho(f"{error}: {tb}", fg="red")
+            click.secho(f"{path}: {error}: {tb}", fg="red")
         else:
-            click.secho(f"{error}", fg="red")
+            click.secho(f"{path}: {error}", fg="red")
 
 
 def _make_result(path: Path, violations: Iterable[LintViolation]) -> Iterable[Result]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #283

This tracks exit codes based on the existence of violations and/or
errors when linting files.

- 0: everything clean
- 1: violations only
- 2: errors only
- 3: both violations and errors

Fixes #258