### PR TITLE
Remove unused Sphinx inventories

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,8 +57,6 @@ autodoc_member_order = "groupwise"
 highlight_language = "python3"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "pathspec": ("https://python-path-specification.readthedocs.io/en/latest/", None),
-    "stdlib_list": ("https://python-stdlib-list.readthedocs.io/en/latest/", None),
 }
 master_doc = "index"
 


### PR DESCRIPTION
## Summary
Remove unused inventories from `docs/conf.py`.

These are not used, and `stdlib_list` has not been updated since 2015.

## Test Plan
After removing, documentation builds fine for the upcoming update of the Fedora package.