### PR TITLE
Apply multiple autofixes using a custom transformer

### DIFF
--- a/examples/basic/custom_object.py
+++ b/examples/basic/custom_object.py
@@ -7,3 +7,6 @@
 class Foo(object):
     def bar(self, value: str) -> str:
         return "value is {}".format(value)
+
+class Bar(object):
+    pass

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -21,7 +21,7 @@ from typing import (
     Union,
 )
 
-from libcst import CSTNode, FlattenSentinel, RemovalSentinel
+from libcst import CSTNode, CSTNodeT, FlattenSentinel, RemovalSentinel
 from libcst._add_slots import add_slots
 from libcst.metadata import CodePosition as CodePosition, CodeRange as CodeRange
 
@@ -35,7 +35,7 @@ RuleOptionTypes = (str, int, float)
 RuleOptions = Dict[str, Union[str, int, float]]
 RuleOptionsTable = Dict[str, RuleOptions]
 
-NodeReplacement = Union[CSTNode, FlattenSentinel, RemovalSentinel]
+NodeReplacement = Union[CSTNodeT, FlattenSentinel[CSTNodeT], RemovalSentinel]
 
 Timings = Dict[str, int]
 TimingsHook = Callable[[Timings], None]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #328

`deep_replace` changes all of the node ID's, making subsequent
replacements fail to find their original nodes, resulting in only a
single autofix applying per file.

This replaces `deep_replace` with a custom transformer that tracks
replacements manually, and then returns the final updated module with
all of the autofixes applied.

Includes test cases and changes to examples to exercise this
functionality to prevent future regressions.

Fixes #322