### PR TITLE
Apply multiple autofixes using a custom transformer

### DIFF
--- a/examples/basic/custom_object.py
+++ b/examples/basic/custom_object.py
@@ -7,3 +7,6 @@
 class Foo(object):
     def bar(self, value: str) -> str:
         return "value is {}".format(value)
+
+class Bar(object):
+    pass

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -11,11 +11,18 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Collection, Iterable, Iterator, Mapping, Optional, Set
 
-from libcst import Module, parse_module
+from libcst import CSTNode, CSTTransformer, Module, parse_module
 from libcst.metadata import FullRepoManager, MetadataWrapper, ProviderT
 from moreorless import unified_diff
 
-from .ftypes import Config, FileContent, LintViolation, Timings, TimingsHook
+from .ftypes import (
+    Config,
+    FileContent,
+    LintViolation,
+    NodeReplacement,
+    Timings,
+    TimingsHook,
+)
 from .rule import LintRule
 
 LOG = logging.getLogger(__name__)
@@ -105,9 +112,18 @@ class LintRunner:
         """
         Apply any autofixes to the module, and return the resulting source code.
         """
-        for violation in violations:
-            if violation.replacement:
-                self.module = self.module.deep_replace(
-                    violation.node, violation.replacement  # type:ignore # LibCST#906
-                )
-        return self.module.bytes
+        replacements = {v.node: v.replacement for v in violations if v.replacement}
+
+        class ReplacementTransformer(CSTTransformer):
+            def on_visit(self, node: CSTNode) -> bool:
+                # don't visit children if we're going to replace the parent anyways
+                return node not in replacements
+
+            def on_leave(self, node: CSTNode, updated: CSTNode) -> NodeReplacement:
+                if node in replacements:
+                    new = replacements[node]
+                    return new
+                return updated
+
+        updated = self.module.visit(ReplacementTransformer())
+        return updated.bytes

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -21,7 +21,7 @@ from typing import (
     Union,
 )
 
-from libcst import CSTNode, FlattenSentinel, RemovalSentinel
+from libcst import CSTNode, CSTNodeT, FlattenSentinel, RemovalSentinel
 from libcst._add_slots import add_slots
 from libcst.metadata import CodePosition as CodePosition, CodeRange as CodeRange
 
@@ -35,7 +35,7 @@ RuleOptionTypes = (str, int, float)
 RuleOptions = Dict[str, Union[str, int, float]]
 RuleOptionsTable = Dict[str, RuleOptions]
 
-NodeReplacement = Union[CSTNode, FlattenSentinel, RemovalSentinel]
+NodeReplacement = Union[CSTNodeT, FlattenSentinel[CSTNodeT], RemovalSentinel]
 
 Timings = Dict[str, int]
 TimingsHook = Callable[[Timings], None]

--- a/src/fixit/tests/smoke.py
+++ b/src/fixit/tests/smoke.py
@@ -3,8 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections import defaultdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from textwrap import dedent
 from unittest import TestCase
 
 from click.testing import CliRunner
@@ -65,3 +67,79 @@ class SmokeTest(TestCase):
             self.assertIn("dirty.py@2:6 UseFstringRule:", result.output)
             self.assertIn("broken.py: EXCEPTION: Syntax Error @ 1:6.", result.output)
             self.assertEqual(result.exit_code, 3)
+
+    def test_directory_with_autofixes(self) -> None:
+        with TemporaryDirectory() as td:
+            tdp = Path(td).resolve()
+            clean = tdp / "clean.py"
+            clean.write_text(
+                dedent(
+                    """
+                    GLOBAL = 'hello'
+
+                    def foo():
+                        value = 'test'
+                        if value is False:
+                            pass
+                    """
+                )
+            )
+            single = tdp / "single.py"
+            single.write_text(
+                dedent(
+                    """
+                    GLOBAL = f'hello'
+
+                    def foo():
+                        value = 'test'
+                        if value is False:
+                            pass
+                    """
+                )
+            )
+            multi = tdp / "multi.py"
+            multi.write_text(
+                dedent(
+                    """
+                    GLOBAL = f'hello'
+
+                    def foo():
+                        value = f'test'
+                        if value == False:
+                            pass
+                    """
+                )
+            )
+
+            expected = clean.read_text()
+
+            result = self.runner.invoke(main, ["fix", "--automatic", td])
+            errors = defaultdict(list)
+            for line in result.output.splitlines():
+                fn, _, error = line.partition("@")
+                short, _, _ = error.partition(": ")
+                errors[Path(fn)].append(short)
+
+            with self.subTest("clean"):
+                self.assertListEqual([], errors[clean])
+                self.assertEqual(expected, clean.read_text())
+
+            with self.subTest("single fix"):
+                self.assertListEqual(
+                    [
+                        "2:9 NoRedundantFStringRule",
+                    ],
+                    sorted(errors[single]),
+                )
+                self.assertEqual(expected, single.read_text())
+
+            with self.subTest("multiple fixes"):
+                self.assertListEqual(
+                    [
+                        "2:9 NoRedundantFStringRule",
+                        "5:12 NoRedundantFStringRule",
+                        "6:7 CompareSingletonPrimitivesByIsRule",
+                    ],
+                    sorted(errors[multi]),
+                )
+                self.assertEqual(expected, multi.read_text())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #329
* #330

`deep_replace` changes all of the node ID's, making subsequent
replacements fail to find their original nodes, resulting in only a
single autofix applying per file.

This replaces `deep_replace` with a custom transformer that tracks
replacements manually, and then returns the final updated module with
all of the autofixes applied.

Includes test cases and changes to examples to exercise this
functionality to prevent future regressions.

Fixes #322