### PR TITLE
Add support for target version and rule filtering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,20 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+# -- Patch python domain signature regex to allow "foo-bar" style names ------
+
+import re
+# modified from sphinx/domains/python.py
+py_sig_re = re.compile(
+    r'''^ ([\w.]*\.)?            # class name(s)
+          ([\w-]+)  \s*             # thing name
+          (?: \(\s*(.*)\s*\)     # optional: arguments
+           (?:\s* -> \s* (.*))?  #           return annotation
+          )? $                   # and nothing more
+          ''', re.VERBOSE)
+
+from sphinx.domains import python
+python.py_sig_re = py_sig_re
 
 # -- Project information -----------------------------------------------------
 
@@ -63,6 +77,7 @@ autodoc_typehints_format = "short"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "libcst": ("https://libcst.rtfd.io/en/latest", None),
+    "packaging": ("https://packaging.pypa.io/en/latest", None),
 }
 master_doc = "index"
 

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -1223,13 +1223,16 @@ unless explicitly listed in the :attr:`disable` configuration option.
             )
 .. class:: UseTypesFromTypingRule
 
-    Enforces the use of types from the ``typing`` module in type annotations in place of ``builtins.{builtin_type}``
-    since the type system doesn't recognize the latter as a valid type.
+    Enforces the use of types from the ``typing`` module in type annotations in place
+    of ``builtins.{builtin_type}`` since the type system doesn't recognize the latter
+    as a valid type before Python ``3.10``.
     
 
     .. attribute:: AUTOFIX
         :type: Yes
 
+    .. attribute:: PYTHON_VERSION
+        :type: '< 3.10'
 
     .. attribute:: VALID
 

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -84,6 +84,17 @@ The main configuration table.
 
     See :attr:`enable` for details on referencing lint rules.
 
+.. attribute:: python-version
+    :type: str
+    :value: "3.10"
+
+    Python version to target when selecting lint rules. Rules with
+    :attr:`~fixit.LintRule.PYTHON_VERSION` specifiers that don't match this
+    target version will be automatically disabled during linting.
+    
+    Defaults to the currently active version of Python.
+    Set to empty string ``""`` to disable target version checking.
+
 
 ``[tool.fixit.options]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "click >= 8.0",
     "libcst >= 0.3.18",
     "moreorless >= 0.4.0",
+    "packaging >= 21",
     "tomli >= 2.0; python_version < '3.11'",
     "trailrunner >= 1.2",
 ]
@@ -114,6 +115,7 @@ disable = [
     # We need noqa for compat with flake8 until we jettison flake8
     "fixit.rules:UseLintFixmeCommentRule",
 ]
+python_version = "3.10"
 
 [[tool.fixit.overrides]]
 path = "examples"

--- a/scripts/document_rules.py
+++ b/scripts/document_rules.py
@@ -45,6 +45,10 @@ unless explicitly listed in the :attr:`disable` configuration option.
         :type: Yes
 
 {% endif %}
+{% if rule.PYTHON_VERSION %}
+    .. attribute:: PYTHON_VERSION
+        :type: {{ repr(rule.PYTHON_VERSION) }}
+{% endif %}
 
     .. attribute:: VALID
 

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import platform
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,6 +26,8 @@ from libcst import CSTNode, CSTNodeT, FlattenSentinel, RemovalSentinel
 from libcst._add_slots import add_slots
 from libcst.metadata import CodePosition as CodePosition, CodeRange as CodeRange
 
+from packaging.version import Version
+
 T = TypeVar("T")
 
 CodeRange
@@ -42,6 +45,8 @@ TimingsHook = Callable[[Timings], None]
 
 VisitorMethod = Callable[[CSTNode], None]
 VisitHook = Callable[[str], ContextManager]
+
+Version
 
 
 @dataclass(frozen=True)
@@ -125,6 +130,9 @@ class Config:
     )
     disable: List[QualifiedRule] = field(default_factory=list)
     options: RuleOptionsTable = field(default_factory=dict)
+
+    # filtering criteria
+    python_version: Optional[Version] = Version(platform.python_version())
 
     def __post_init__(self):
         self.path = self.path.resolve()

--- a/src/fixit/rules/use_types_from_typing.py
+++ b/src/fixit/rules/use_types_from_typing.py
@@ -23,9 +23,12 @@ QUALIFIED_BUILTINS_TO_REPLACE: Set[str] = {f"builtins.{s}" for s in BUILTINS_TO_
 
 class UseTypesFromTypingRule(CstLintRule):
     """
-    Enforces the use of types from the ``typing`` module in type annotations in place of ``builtins.{builtin_type}``
-    since the type system doesn't recognize the latter as a valid type.
+    Enforces the use of types from the ``typing`` module in type annotations in place
+    of ``builtins.{builtin_type}`` since the type system doesn't recognize the latter
+    as a valid type before Python ``3.10``.
     """
+
+    PYTHON_VERSION = "< 3.10"
 
     METADATA_DEPENDENCIES = (
         QualifiedNameProvider,

--- a/src/fixit/tests/__init__.py
+++ b/src/fixit/tests/__init__.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fixit.config import collect_rules
+from fixit.config import collect_rules, Config
 from fixit.ftypes import QualifiedRule
 
 from fixit.testing import add_lint_rule_tests_to_module
@@ -14,5 +14,5 @@ from .smoke import SmokeTest
 
 add_lint_rule_tests_to_module(
     globals(),
-    collect_rules(enables=[QualifiedRule("fixit.rules")], disables=[]),
+    collect_rules(Config(enable=[QualifiedRule("fixit.rules")], python_version=None)),
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

- Adds `PYTHON_VERSION` attribute to lint rules to specify compatibility
- Adds `python-version` option to config files to select target version
- Filter out rules by configured target version when collecting
- Document new options and attributes

Also includes:

- Parameters for debugging reason for disabled rules when collecting
- Better string form of rules to display module and class name
- Updates to `debug` command to use new string names, and show disabled
  rules and the reasons they were disabled

Fixes #302