### PR TITLE
Support use of tags for selecting/filtering rules

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,10 +29,12 @@ Simple API
 Advanced API
 ^^^^^^^^^^^^
 
-.. autoclass:: fixit.ftypes.FileContent
+.. autoclass:: fixit.FileContent
 
 .. autofunction:: fixit_bytes
 .. autoclass:: fixit.util.capture
 
 .. autoclass:: Config
+.. autoclass:: Options
 .. autoclass:: QualifiedRule
+.. autoclass:: Tags

--- a/docs/guide/commands.rst
+++ b/docs/guide/commands.rst
@@ -3,6 +3,46 @@
 Commands
 --------
 
+.. code:: console
+
+    $ fixit [OPTIONS] COMMAND ...
+
+
+The following options are available for all commands:
+
+.. attribute:: --debug / --quiet
+
+    Raise or lower the level of output and logging.
+
+.. attribute:: --config-file PATH
+
+    Override the normal hierarchical configuration and use the configuration
+    from the specified path, ignoring all other configuration files entirely.
+
+.. attribute:: --tags TAGS
+
+    Select or filter the set of lint rules to apply based on their tags.
+
+    Takes a comma-separated list of tag names, optionally prefixed with ``!``,
+    ``^``, or ``-``. Tags without one of those prefixes will be considered
+    "include" tags, while tags with one of those prefixes will be considered
+    "exclude" tags.
+
+    Lint rules will be enabled if and only if they have at least one tag that
+    in the "include" list, and no tags in the "exclude" list.
+
+    For example:
+
+    .. code:: console
+
+        $ fixit --tags "hello, world, ^cats" ...
+
+    The command above will filter the set of enabled lint rules to ones that
+    have either the "hello" or "world" tags, and exclude any rules with the
+    "cats" tag, even if they would have otherwise been selected by the other
+    two tags.
+
+
 ``lint``
 ^^^^^^^^
 

--- a/src/fixit/__init__.py
+++ b/src/fixit/__init__.py
@@ -15,8 +15,10 @@ from .ftypes import (
     Config,
     FileContent,
     LintViolation,
+    Options,
     QualifiedRule,
     Result,
+    Tags,
 )
 from .rule import CSTLintRule, CstLintRule, LintRule
 from .testing import InvalidTestCase, ValidTestCase
@@ -35,8 +37,10 @@ __all__ = [
     "ValidTestCase",
     "Config",
     "FileContent",
+    "Options",
     "QualifiedRule",
     "Result",
+    "Tags",
     "CodeRange",
     "CodePosition",
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #333
* #332

- Add `Tags` class to track include/exclude, with parse helper, and
  contains and bool methods to make comparison easy.
- Add `--tags` option to CLI and `Options` object, and pass through to
  config generation to apply to final materialized config.
- Add new filtering to `collect_rules` to compare rule's tags against
  the configured set of include/exclude tags.
- No includes given implies selecting all rules (not accounting for
  disabled rules, target python version, etc).

Fixes #303, #304