### PR TITLE
Implement basic lint-ignore and lint-fixme directives

### DIFF
--- a/docs/guide/quickstart.rst
+++ b/docs/guide/quickstart.rst
@@ -57,8 +57,74 @@ When running Fixit, we see two separate lint errors:
 .. code:: console
 
     $ fixit lint custom_object.py
-    custom_object.py@4:15 UseFstringRule: Do not use printf style formatting or .format(). Use f-string instead to be more readable and efficient. See https://www.python.org/dev/peps/pep-0498/
-    custom_object.py@2:0 NoInheritFromObjectRule: Inheriting from object is a no-op.  'class Foo:' is just fine =)
+    custom_object.py@4:15 UseFstring: Do not use printf style formatting or .format(). Use f-string instead to be more readable and efficient. See https://www.python.org/dev/peps/pep-0498/
+    custom_object.py@2:0 NoInheritFromObject: Inheriting from object is a no-op.  'class Foo:' is just fine =)
+
+We can also see any suggested changes by passing ``--diff``:
+
+.. code:: console
+
+    $ fixit lint --diff custom_object.py
+    custom_object.py@7:0 NoInheritFromObject: Inheriting from object is a no-op.  'class Foo:' is just fine =) (has autofix)
+    --- a/custom_object.py
+    +++ b/custom_object.py
+    @@ -6,3 +6,3 @@
+    # Triggers built-in lint rules
+    -class Foo(object):
+    +class Foo:
+        def bar(self, value: str) -> str:
+    custom_object.py@9:15 UseFstring: Do not use printf style formatting or .format(). Use f-string instead to be more readable and efficient. See https://www.python.org/dev/peps/pep-0498/
+    🛠️  1 file checked, 1 file with errors, 1 auto-fix available 🛠️
+
+
+Silencing Errors
+^^^^^^^^^^^^^^^^
+
+For lint rules without autofixes, it may still be useful to silence individual
+errors. A simple ``# lint-ignore`` or ``# lint-fixme`` comment, either as
+a trailing inline comment, or as a dedicated comment line above the code that
+triggered the lint rule:
+
+.. code:: python
+
+    class Foo(object):  # lint-fixme: NoInheritFromObject
+        ...
+
+    # lint-ignore: NoInheritFromObject
+    class Bar(object):
+        ...
+
+By providing one or more lint rule, separated by commas, Fixit can still report
+issues triggered by other lint rules that haven't been listed in the comment,
+but this is not required.
+
+If no rule name is listed, Fixit will silence all rules when reported on code
+associated with that comment:
+
+.. code-block:: python
+
+    class Foo(object):  # lint-ignore
+        ...
+
+
+"ignore" vs "fixme"
+%%%%%%%%%%%%%%%%%%%
+
+Both comment directives achieve the same result — silencing errors for
+a particular statement of code. The semantics of using either term is left to
+the user, though they are intended to be used with the following meanings:
+
+- ``# lint-fixme`` for errors that need to be corrected or reviewed at a later
+  date, but where the lint rule should be silenced temporarily for the sake
+  of CI or similar external circumstances.
+
+- ``# lint-ignore`` for errors that are false-positives (please report issues
+  if this occurs with built-in lint rules) or the code is otherwise
+  intentionally written or structured in a way that the lint error cannot
+  be avoided.
+
+Future versions of Fixit may offer reporting or similar tools that treat
+"fixme" directives differently from "ignore" directives.
 
 
 Custom Rules
@@ -144,7 +210,7 @@ Once enabled, Fixit can run that new lint rule against the codebase:
 .. code:: console
 
     $ fixit lint --diff sourdough/baker.py
-    sourdough/baker.py@7:11 HollywoodNameRule: It's underproved! (has autofix)
+    sourdough/baker.py@7:11 HollywoodName: It's underproved! (has autofix)
     --- a/baker.py
     +++ b/baker.py
     @@ -6,3 +6,3 @@
@@ -161,7 +227,7 @@ The ``fix`` command will apply these suggested changes to the codebase:
 .. code:: console
 
     $ fixit fix --automatic sourdough/baker.py
-    sourdough/baker.py@7:11 HollywoodNameRule: It's underproved! (has autofix)
+    sourdough/baker.py@7:11 HollywoodName: It's underproved! (has autofix)
     🛠️  1 file checked, 1 file with errors, 1 auto-fix available, 1 fix applied 🛠️
 
 By default, the ``fix`` command will interactively prompt the user for each

--- a/examples/basic/custom_object.py
+++ b/examples/basic/custom_object.py
@@ -8,5 +8,20 @@ class Foo(object):
     def bar(self, value: str) -> str:
         return "value is {}".format(value)
 
+# lint-fixme: SomethingUnrelated
 class Bar(object):
+    pass
+
+
+# lint-ignore
+class Phi(object):
+    pass
+
+
+# lint-fixme: NoInheritFromObject
+class Rho(object):
+    pass
+
+
+class Zeta(object):  # lint-ignore NoInheritFromObject
     pass

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -64,6 +64,22 @@ class ValidTestCase:
     code: str
 
 
+LintIgnoreRegex = re.compile(
+    r"""
+    \#\s*                   # leading hash and whitespace
+    (lint-(?:ignore|fixme)) # directive
+    (?:
+        (?::\s*|\s+)        # separator
+        (
+            \w+             # first rule name
+            (?:,\s*\w+)*    # subsequent rule names
+        )
+    )?                      # rule names are optional
+    """,
+    re.VERBOSE,
+)
+
+
 QualifiedRuleRegex = re.compile(
     r"""
     ^

--- a/src/fixit/rule.py
+++ b/src/fixit/rule.py
@@ -163,7 +163,7 @@ class LintRule(BatchableCSTVisitor):
         """
         rule_names = (self.name, self.name.lower())
         for comment in self.node_comments(node):
-            if match := LintIgnoreRegex.match(comment):
+            if match := LintIgnoreRegex.search(comment):
                 _style, names = match.groups()
 
                 # directive

--- a/src/fixit/tests/ftypes.py
+++ b/src/fixit/tests/ftypes.py
@@ -17,6 +17,7 @@ class TypesTest(TestCase):
             ("# lint-ignore:FakeRule", "FakeRule"),
             ("# lint-ignore: Fake", "Fake"),
             ("# lint-fixme: Fake,Another", "Fake,Another"),
+            ("#lint-fixme:Fake,Another", "Fake,Another"),
             ("#lint-fixme Fake, Another, Name", "Fake, Another, Name"),
         ):
             with self.subTest("match " + value):

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -89,7 +89,7 @@ class RuleTest(TestCase):
         self.assertEqual(
             violation,
             LintViolation(
-                "ExerciseReportRule",
+                "ExerciseReport",
                 CodeRange(start=CodePosition(1, 0), end=CodePosition(1, 4)),
                 "I pass",
                 violation.node,
@@ -104,7 +104,7 @@ class RuleTest(TestCase):
         self.assertEqual(
             violation,
             LintViolation(
-                "ExerciseReportRule",
+                "ExerciseReport",
                 CodeRange(start=CodePosition(1, 1), end=CodePosition(2, 0)),
                 "I ellipse",
                 violation.node,

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
+from textwrap import dedent
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -65,6 +66,10 @@ class RunnerTest(TestCase):
 class ExerciseReportRule(LintRule):
     MESSAGE = "message on the class"
 
+    def visit_ClassDef(self, node: cst.ClassDef) -> bool:
+        self.report(node, "class def")
+        return False
+
     def visit_Pass(self, node: cst.Pass) -> bool:
         self.report(node, "I pass")
         return False
@@ -117,3 +122,113 @@ class RuleTest(TestCase):
         violations = list(runner.collect_violations(self.rules, Config()))
         self.assertEqual(len(violations), 1)
         self.assertEqual(violations[0].message, "message on the class")
+
+    def test_ignore_lint(self) -> None:
+        idx = 0
+        for code, message, position in (
+            ("pass  # random comment\n", "I pass", (1, 0)),
+            ("pass\n", "I pass", (1, 0)),
+            ("pass  # lint-fixme\n", None, None),
+            ("pass  # lint-ignore\n", None, None),
+            ("pass  # lint-fixme: ExerciseReport\n", None, None),
+            ("pass  # lint-ignore: ExerciseReport\n", None, None),
+            ("pass  # lint-fixme: SomethingElse, ExerciseReport\n", None, None),
+            ("pass  # lint-ignore: SomethingElse, ExerciseReport\n", None, None),
+            ("pass  # lint-fixme: SomethingElse\n", "I pass", (1, 0)),
+            ("pass  # lint-ignore: SomethingElse\n", "I pass", (1, 0)),
+            ("# random comment\npass\n", "I pass", (2, 0)),
+            ("# lint-fixme\npass\n", None, None),
+            ("# lint-ignore\npass\n", None, None),
+            ("# lint-fixme: ExerciseReport\npass\n", None, None),
+            ("# lint-ignore: ExerciseReport\npass\n", None, None),
+            ("# lint-fixme: SomethingElse, ExerciseReport\npass\n", None, None),
+            ("# lint-ignore: SomethingElse, ExerciseReport\npass\n", None, None),
+            ("# lint-fixme: SomethingElse\npass\n", "I pass", (2, 0)),
+            ("# lint-ignore: SomethingElse\npass\n", "I pass", (2, 0)),
+            ("def foo(bar): pass\n", "I pass", (1, 14)),
+            ("def foo(bar): pass  # lint-ignore\n", None, None),
+            ("# lint-ignore\ndef foo(bar): pass\n", None, None),
+            ("import sys\n# lint-ignore\ndef foo(bar): pass\n", None, None),
+            ("class bar(object): value = 1\n", "class def", (1, 0)),
+            ("class bar(object): value = 1  # lint-fixme\n", None, None),
+            ("# lint-fixme\nclass bar(object): value = 1\n", None, None),
+            ("import sys\n# lint-fixme\nclass bar(object): value = 1\n", None, None),
+            (
+                """
+                    import sys
+
+                    class Foo(object):
+                        value = 1
+                """,
+                "class def",
+                (4, 0),
+            ),
+            (
+                """
+                    import sys
+
+                    class Foo(object):  # comment
+                        value = 1
+                """,
+                "class def",
+                (4, 0),
+            ),
+            (
+                """
+                    import sys
+
+                    class Foo(object):  # lint-ignore
+                        value = 1
+                """,
+                None,
+                None,
+            ),
+            (
+                """
+                    import sys
+
+                    class Foo(object):  # lint-ignore ExerciseReport
+                        value = 1
+                """,
+                None,
+                None,
+            ),
+            (
+                """
+                    import sys
+
+                    # lint-fixme
+                    class Foo(object):
+                        value = 1
+                """,
+                None,
+                None,
+            ),
+            (
+                """
+                    import sys
+
+                    # lint-fixme: UnrelatedRule
+                    class Foo(object):
+                        value = 1
+                """,
+                "class def",
+                (5, 0),
+            ),
+        ):
+            idx += 1
+            content = dedent(code).encode("utf-8")
+            with self.subTest(f"code {idx}"):
+                runner = LintRunner(Path("fake.py"), content)
+                violations = list(
+                    runner.collect_violations([ExerciseReportRule()], Config())
+                )
+
+                if message and position:
+                    self.assertEqual(len(violations), 1)
+                    (violation,) = violations
+                    self.assertEqual(violation.message, message)
+                    self.assertEqual(violation.range.start, CodePosition(*position))
+
+                else:
+                    self.assertListEqual([], violations)

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -177,7 +177,7 @@ class RuleTest(TestCase):
                 """
                     import sys
 
-                    class Foo(object):  # lint-ignore
+                    class Foo(object):  # type: ignore # lint-ignore
                         value = 1
                 """,
                 None,
@@ -197,7 +197,7 @@ class RuleTest(TestCase):
                 """
                     import sys
 
-                    # lint-fixme
+                    # type:ignore  # lint-fixme  # justification
                     class Foo(object):
                         value = 1
                 """,
@@ -231,4 +231,6 @@ class RuleTest(TestCase):
                     self.assertEqual(violation.range.start, CodePosition(*position))
 
                 else:
-                    self.assertListEqual([], violations)
+                    self.assertEqual(
+                        len(violations), 0, "Unexpected lint errors reported"
+                    )

--- a/src/fixit/tests/smoke.py
+++ b/src/fixit/tests/smoke.py
@@ -43,7 +43,7 @@ class SmokeTest(TestCase):
             (tdp / "dirty.py").write_text("name = 'Kirby'\nprint('hello %s' % name)\n")
 
             result = self.runner.invoke(main, ["lint", td])
-            self.assertIn("dirty.py@2:6 UseFstringRule:", result.output)
+            self.assertIn("dirty.py@2:6 UseFstring:", result.output)
             self.assertEqual(result.exit_code, 1)
 
     def test_directory_with_errors(self) -> None:
@@ -64,7 +64,7 @@ class SmokeTest(TestCase):
             (tdp / "broken.py").write_text("print)\n")
 
             result = self.runner.invoke(main, ["lint", td])
-            self.assertIn("dirty.py@2:6 UseFstringRule:", result.output)
+            self.assertIn("dirty.py@2:6 UseFstring:", result.output)
             self.assertIn("broken.py: EXCEPTION: Syntax Error @ 1:", result.output)
             self.assertEqual(result.exit_code, 3)
 
@@ -127,7 +127,7 @@ class SmokeTest(TestCase):
             with self.subTest("single fix"):
                 self.assertListEqual(
                     [
-                        "2:9 NoRedundantFStringRule",
+                        "2:9 NoRedundantFString",
                     ],
                     sorted(errors[single]),
                 )
@@ -136,9 +136,9 @@ class SmokeTest(TestCase):
             with self.subTest("multiple fixes"):
                 self.assertListEqual(
                     [
-                        "2:9 NoRedundantFStringRule",
-                        "5:12 NoRedundantFStringRule",
-                        "6:7 CompareSingletonPrimitivesByIsRule",
+                        "2:9 NoRedundantFString",
+                        "5:12 NoRedundantFString",
+                        "6:7 CompareSingletonPrimitivesByIs",
                     ],
                     sorted(errors[multi]),
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #334

- `LintIgnoreRegex` to define directive syntax
- `LintRule.node_comments` to yield associated comments
- `LintRule.ignore_lint` to check comments for matching directives
- `LintRule.report` will drop violation if `LintRule.ignore_lint`
  returns truthy value
- Plenty of test cases, and example updates, to cover expected usage
- Documented in quick start as "silencing errors"

Fixes #301