### PR TITLE
Add support for formatting code after applying fixes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,3 +38,9 @@ Advanced API
 .. autoclass:: Options
 .. autoclass:: QualifiedRule
 .. autoclass:: Tags
+
+
+Formatters
+----------
+
+.. autoclass:: Formatter

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -95,6 +95,25 @@ The main configuration table.
     Defaults to the currently active version of Python.
     Set to empty string ``""`` to disable target version checking.
 
+.. attribute:: formatter
+    :type: str
+    :value: None
+
+    Code formatting style to apply after fixing source files.
+
+    Supported code styles:
+
+    - ``None``: No style is applied (default).
+
+    - ``"black"``: `Black <https://black.rtfd.io>`_ code formatter.
+
+    - ``"ufmt"``: `µfmt <https://ufmt.omnilib.dev>`_ code style —
+      `µsort <https://usort.rtfd.io>`_ import sorting with
+      `Black <https://black.rtfd.io>`_ code formatting.
+
+    Alternative formatting styles can be added by implementing the
+    :class:`~fixit.Formatter` interface.
+
 
 ``[tool.fixit.options]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ check = [
     "python scripts/check_copyright.py",
 ]
 fix = [
+    "fixit fix --automatic src/fixit scripts",
     "ufmt format src/fixit scripts",
 ]
 
@@ -117,6 +118,7 @@ disable = [
     "fixit.rules:UseLintFixmeCommentRule",
 ]
 python_version = "3.10"
+formatter = "ufmt"
 
 [[tool.fixit.overrides]]
 path = "examples"

--- a/src/fixit/__init__.py
+++ b/src/fixit/__init__.py
@@ -9,6 +9,7 @@ Linting framework built on LibCST, with automatic fixes
 
 from .__version__ import __version__
 from .api import fixit_bytes, fixit_file, fixit_paths, print_result
+from .format import Formatter
 from .ftypes import (
     CodePosition,
     CodeRange,
@@ -31,6 +32,7 @@ __all__ = [
     "print_result",
     "CSTLintRule",
     "CstLintRule",
+    "Formatter",
     "LintRule",
     "LintViolation",
     "InvalidTestCase",

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -15,6 +15,7 @@ from moreorless.click import echo_color_precomputed_diff
 
 from .config import collect_rules, generate_config
 from .engine import LintRunner
+from .format import format_module
 from .ftypes import Config, FileContent, LintViolation, Options, Result
 
 LOG = logging.getLogger(__name__)
@@ -99,7 +100,7 @@ def fixit_bytes(
 
         if pending_fixes:
             updated = runner.apply_replacements(pending_fixes)
-            return updated
+            return format_module(updated, path, config)
 
     except Exception as error:
         # TODO: this is not the right place to catch errors

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -108,7 +108,7 @@ class LintRunner:
 
         return count
 
-    def apply_replacements(self, violations: Collection[LintViolation]) -> FileContent:
+    def apply_replacements(self, violations: Collection[LintViolation]) -> Module:
         """
         Apply any autofixes to the module, and return the resulting source code.
         """
@@ -125,5 +125,5 @@ class LintRunner:
                     return new
                 return updated
 
-        updated = self.module.visit(ReplacementTransformer())
-        return updated.bytes
+        updated: Module = self.module.visit(ReplacementTransformer())
+        return updated

--- a/src/fixit/format.py
+++ b/src/fixit/format.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Post-transform file formatters.
+
+NOTE: be sure to update docs/guide/configuration.rst to include any new formatters.
+"""
+
+from pathlib import Path
+from typing import Dict, Optional, Type
+
+from libcst import Module
+
+from .ftypes import Config, FileContent
+
+FORMAT_STYLES: Dict[Optional[str], Type["Formatter"]] = {}
+
+
+class Formatter:
+    """
+    Fixit post-transform code style and formatting interface.
+    """
+
+    STYLE: str
+    """
+    Short name to identify this formatting style in user configuration.
+    For example: ``"black"``.
+    """
+
+    def __init_subclass__(cls) -> None:
+        FORMAT_STYLES[cls.STYLE] = cls
+
+    def format(self, module: Module, path: Path) -> FileContent:
+        """
+        Format the given :class:`~libcst.Module` and return it as UTF-8 encoded bytes.
+        """
+        return module.bytes
+
+
+class BlackFormatter(Formatter):
+    STYLE = "black"
+
+    def format(self, module: Module, path: Path) -> FileContent:
+        import black
+        import ufmt.util
+
+        mode = ufmt.util.make_black_config(path)
+        content = black.format_file_contents(
+            module.bytes.decode("utf-8"), fast=False, mode=mode
+        )
+        return content.encode("utf-8")
+
+
+class UfmtFormatter(Formatter):
+    STYLE = "ufmt"
+
+    def format(self, module: Module, path: Path) -> FileContent:
+        import ufmt
+        import ufmt.util
+
+        black_config = ufmt.util.make_black_config(path)
+        usort_config = ufmt.UsortConfig.find(path)
+
+        return ufmt.ufmt_bytes(
+            path, module.bytes, black_config=black_config, usort_config=usort_config
+        )
+
+
+def format_module(module: Module, path: Path, config: Config) -> FileContent:
+    """
+    Format the given source module, and return its final content in bytes.
+
+    Uses the ``config`` object to instantiate the correct :class:`Formatter` style.
+    """
+    formatter = FORMAT_STYLES[config.formatter]()
+    return formatter.format(module, path)
+
+
+FORMAT_STYLES[None] = Formatter

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -202,6 +202,9 @@ class Config:
     )
     tags: Tags = field(default_factory=Tags)
 
+    # post-run processing
+    formatter: Optional[str] = None
+
     def __post_init__(self):
         self.path = self.path.resolve()
         self.root = self.root.resolve()

--- a/src/fixit/testing.py
+++ b/src/fixit/testing.py
@@ -114,7 +114,7 @@ class LintRuleTestCase(unittest.TestCase):
         if test_case.expected_replacement:
             # make sure we produced expected final code
             expected_code = _dedent(test_case.expected_replacement)
-            modified_code = runner.apply_replacements([report]).decode()
+            modified_code = runner.apply_replacements([report]).bytes.decode()
             self.assertMultiLineEqual(expected_code, modified_code)
 
             # make sure we generated a reasonable diff


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #335

- New `formatter` config option
- New `Formatter` class and `format_module` to define formatting
  interface and method of tracking available formatters.
- Builtin support for `black` and `ufmt` styles
- Prototype support for alternative formatters by extending the
  `Formatter` class at runtime
- Updated configuration guide, and added formatter section to API docs

Fixes #307