### PR TITLE
Option for absolute rule imports from project root

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -84,6 +84,41 @@ The main configuration table.
 
     See :attr:`enable` for details on referencing lint rules.
 
+.. attribute:: enable-root-import
+    :type: bool | str
+    :value: False
+
+    Allow importing local rules using absolute imports, relative to the root
+    of the project. This provides an alternative to using dotted rule names for
+    enabling and importing local rules (see :attr:`enable`) from either the
+    directory containing the root config (when set to ``true``), or a single,
+    optional path relative to the root config.
+
+    For example, project ``orange`` using a ``src/orange/`` project hierarchy
+    could use the following config:
+
+    .. code-block:: toml
+
+        # pyproject.toml
+        [tool.fixit]
+        root = True
+        enable-root-import = "src"
+        enable = ["orange.rules"]
+
+    Assuming that the namespace ``orange`` is not already in site-packages,
+    then ``orange.rules`` would be imported from ``src/orange/rules/``, while
+    also allowing these local rules to import from other components in the
+    ``orange`` namespace.
+
+    This option may only be specified in the root config file. Specifying the
+    option in any other config file is treated as a configuration error.
+    Absolute paths, or paths containing ``..`` parent-relative components,
+    are not allowed.
+
+    This option is roughly equivalent to adding the configured path, relative
+    to the root configuration, to :attr:`sys.path` when attempting to import
+    and materialize any enabled lint rules.
+
 .. attribute:: python-version
     :type: str
     :value: "3.10"

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -31,11 +31,12 @@ The main configuration table.
 
 .. attribute:: root
     :type: bool
-    :value: False
+    :value: false
 
     Marks this file as a root of the configuration hierarchy.
 
-    If set to ``True``, Fixit will not visit any files further up the hierarchy.
+    If set to ``true``, Fixit will not visit any configuration files further up
+    the filesystem hierarchy.
 
 .. attribute:: enable
     :type: list[str]
@@ -86,7 +87,6 @@ The main configuration table.
 
 .. attribute:: enable-root-import
     :type: bool | str
-    :value: False
 
     Allow importing local rules using absolute imports, relative to the root
     of the project. This provides an alternative to using dotted rule names for
@@ -99,8 +99,6 @@ The main configuration table.
 
     .. code-block:: toml
 
-        # pyproject.toml
-        [tool.fixit]
         root = True
         enable-root-import = "src"
         enable = ["orange.rules"]
@@ -121,24 +119,28 @@ The main configuration table.
 
 .. attribute:: python-version
     :type: str
-    :value: "3.10"
 
     Python version to target when selecting lint rules. Rules with
     :attr:`~fixit.LintRule.PYTHON_VERSION` specifiers that don't match this
     target version will be automatically disabled during linting.
+
+    To target a minimum Python version of 3.10:
+
+    .. code-block:: toml
+
+        python-version = "3.10"
     
     Defaults to the currently active version of Python.
     Set to empty string ``""`` to disable target version checking.
 
 .. attribute:: formatter
     :type: str
-    :value: None
 
     Code formatting style to apply after fixing source files.
 
     Supported code styles:
 
-    - ``None``: No style is applied (default).
+    - ``(unset)``: No style is applied (default).
 
     - ``"black"``: `Black <https://black.rtfd.io>`_ code formatter.
 

--- a/makefile
+++ b/makefile
@@ -1,3 +1,4 @@
+all: format test lint html
 
 .PHONY: venv
 venv:

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -190,6 +190,10 @@ class Config:
     path: Path = field(default_factory=Path)
     root: Path = field(default_factory=Path.cwd)
 
+    # feature flags
+    enable_root_import: Union[bool, Path] = False
+
+    # rule selection
     enable: List[QualifiedRule] = field(
         default_factory=lambda: [QualifiedRule("fixit.rules")]
     )

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -29,6 +29,7 @@ class ConfigTest(TestCase):
                 """
                 [tool.fixit]
                 root = true
+                enable-root-import = true
                 enable = ["more.rules"]
                 disable = ["fixit.rules.SomethingSpecific"]
                 python_version = "3.8"
@@ -168,6 +169,7 @@ class ConfigTest(TestCase):
                         top,
                         {
                             "root": True,
+                            "enable-root-import": True,
                             "enable": ["more.rules"],
                             "disable": ["fixit.rules.SomethingSpecific"],
                             "python_version": "3.8",
@@ -197,6 +199,7 @@ class ConfigTest(TestCase):
                         top,
                         {
                             "root": True,
+                            "enable-root-import": True,
                             "enable": ["more.rules"],
                             "disable": ["fixit.rules.SomethingSpecific"],
                             "python_version": "3.8",
@@ -223,6 +226,7 @@ class ConfigTest(TestCase):
                         top,
                         {
                             "root": True,
+                            "enable-root-import": True,
                             "enable": ["more.rules"],
                             "disable": ["fixit.rules.SomethingSpecific"],
                             "python_version": "3.8",
@@ -356,6 +360,7 @@ class ConfigTest(TestCase):
                 Config(
                     path=self.outer / "foo.py",
                     root=self.tdp,
+                    enable_root_import=True,
                     enable=[
                         QualifiedRule(".localrules", local=".", root=self.outer),
                         QualifiedRule("more.rules"),
@@ -385,6 +390,7 @@ class ConfigTest(TestCase):
                 Config(
                     path=self.tdp / "other" / "foo.py",
                     root=self.tdp,
+                    enable_root_import=True,
                     enable=[
                         QualifiedRule(".globalrules", local=".", root=self.tdp),
                         QualifiedRule("more.rules"),
@@ -405,6 +411,7 @@ class ConfigTest(TestCase):
                 Config(
                     path=self.tdp / "foo.py",
                     root=self.tdp,
+                    enable_root_import=True,
                     enable=[QualifiedRule("fixit.rules"), QualifiedRule("more.rules")],
                     disable=[QualifiedRule("fixit.rules.SomethingSpecific")],
                     python_version=Version("3.8"),
@@ -414,6 +421,16 @@ class ConfigTest(TestCase):
             with self.subTest(name):
                 actual = config.generate_config(path, root)
                 self.assertDictEqual(asdict(expected), asdict(actual))
+
+    def test_invalid_config(self):
+        with self.subTest("inner enable-root-import"):
+            (self.tdp / "pyproject.toml").write_text("[tool.fixit]\nroot = true\n")
+            (self.tdp / "outer" / "pyproject.toml").write_text(
+                "[tool.fixit]\nenable-root-import = true\n"
+            )
+
+            with self.assertRaisesRegex(config.ConfigError, "enable-root-import"):
+                config.generate_config(self.tdp / "outer" / "foo.py")
 
     def test_collect_rules(self):
         from fixit.rules.avoid_or_in_except import AvoidOrInExceptRule

--- a/src/fixit/util.py
+++ b/src/fixit/util.py
@@ -3,6 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+from contextlib import contextmanager
+from pathlib import Path
 from typing import cast, Generator, Generic, Optional, TypeVar, Union
 
 Yield = TypeVar("Yield")
@@ -63,3 +66,24 @@ class capture(Generic[Yield, Send, Return]):
         if self._result is Sentinel:
             raise ValueError("Generator hasn't completed")
         return cast(Return, self._result)
+
+
+@contextmanager
+def append_sys_path(path: Path) -> Generator[None, None, None]:
+    """
+    Append a path to ``sys.path`` temporarily, and then remove it again when done.
+
+    If the given path is already in ``sys.path``, it will not be added a second time,
+    and it will not be removed when leaving the context.
+    """
+    path_str = path.as_posix()
+
+    # not there: append to path, and remove it when leaving the context
+    if path_str not in sys.path:
+        sys.path.append(path_str)
+        yield
+        sys.path.remove(path_str)
+
+    # already there: do nothing, and don't remove it later
+    else:
+        yield


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #340
* __->__ #338
* #339

- New `enable-root-import` config option for root configs
- Add root config directory, or specified relative path, to `sys.path`
  before materializing configured lint rules.
- Tests
- Documentation

Fixes #316