### PR TITLE
Temporarily pin to click < 8.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ docs = [
     "sphinx-mdinclude == 0.5.3",
 ]
 dev = [
+    "click < 8.1.4",  # https://github.com/pallets/click/issues/2558
     "attribution == 1.6.2",
     "black == 23.3.0",
     "flake8 == 6.0.0",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #340
* #338
* __->__ #339

There is a typing issue with click decorators:
https://github.com/pallets/click/issues/2558