### PR TITLE
Consolidate on `python-version` as the config key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ disable = [
     # We need noqa for compat with flake8 until we jettison flake8
     "fixit.rules:UseLintFixmeCommentRule",
 ]
-python_version = "3.10"
+python-version = "3.10"
 formatter = "ufmt"
 
 [[tool.fixit.overrides]]

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -234,7 +234,7 @@ def collect_rules(
         if config.python_version is not None:
             disabled_rules.update(
                 {
-                    R: "python_version"
+                    R: "python-version"
                     for R in all_rules
                     if config.python_version not in SpecifierSet(R.PYTHON_VERSION)
                 }
@@ -427,11 +427,11 @@ def merge_configs(
                     target_python_version = Version(python_version)
                 except InvalidVersion:
                     raise ConfigError(
-                        f"'python_version' {python_version!r} is not valid",
+                        f"'python-version' {python_version!r} is not valid",
                         config=config,
                     )
 
-            else:  # disable versioning, aka python_version = ""
+            else:  # disable versioning, aka python-version = ""
                 target_python_version = None
 
         if formatter:
@@ -474,7 +474,7 @@ def merge_configs(
             enable=get_sequence(config, "enable"),
             disable=get_sequence(config, "disable"),
             options=get_options(config, "options"),
-            python_version=config.data.pop("python_version", None),
+            python_version=config.data.pop("python-version", None),
             formatter=config.data.pop("formatter", None),
         )
 
@@ -494,7 +494,7 @@ def merge_configs(
                 enable=get_sequence(config, "enable", data=override),
                 disable=get_sequence(config, "disable", data=override),
                 options=get_options(config, "options", data=override),
-                python_version=override.pop("python_version", None),
+                python_version=override.pop("python-version", None),
                 formatter=override.pop("formatter", None),
             )
 

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -32,14 +32,14 @@ class ConfigTest(TestCase):
                 enable-root-import = true
                 enable = ["more.rules"]
                 disable = ["fixit.rules.SomethingSpecific"]
-                python_version = "3.8"
+                python-version = "3.8"
 
                 [[tool.fixit.overrides]]
                 path = "other"
                 enable = ["other.stuff", ".globalrules"]
                 disable = ["fixit.rules"]
                 options = {"other.stuff.Whatever"={key="value"}}
-                python_version = "3.10"
+                python-version = "3.10"
                 """
             )
         )
@@ -172,7 +172,7 @@ class ConfigTest(TestCase):
                             "enable-root-import": True,
                             "enable": ["more.rules"],
                             "disable": ["fixit.rules.SomethingSpecific"],
-                            "python_version": "3.8",
+                            "python-version": "3.8",
                             "overrides": [
                                 {
                                     "path": "other",
@@ -181,7 +181,7 @@ class ConfigTest(TestCase):
                                     "options": {
                                         "other.stuff.Whatever": {"key": "value"}
                                     },
-                                    "python_version": "3.10",
+                                    "python-version": "3.10",
                                 },
                             ],
                         },
@@ -202,7 +202,7 @@ class ConfigTest(TestCase):
                             "enable-root-import": True,
                             "enable": ["more.rules"],
                             "disable": ["fixit.rules.SomethingSpecific"],
-                            "python_version": "3.8",
+                            "python-version": "3.8",
                             "overrides": [
                                 {
                                     "path": "other",
@@ -211,7 +211,7 @@ class ConfigTest(TestCase):
                                     "options": {
                                         "other.stuff.Whatever": {"key": "value"}
                                     },
-                                    "python_version": "3.10",
+                                    "python-version": "3.10",
                                 },
                             ],
                         },
@@ -229,7 +229,7 @@ class ConfigTest(TestCase):
                             "enable-root-import": True,
                             "enable": ["more.rules"],
                             "disable": ["fixit.rules.SomethingSpecific"],
-                            "python_version": "3.8",
+                            "python-version": "3.8",
                             "overrides": [
                                 {
                                     "path": "other",
@@ -238,7 +238,7 @@ class ConfigTest(TestCase):
                                     "options": {
                                         "other.stuff.Whatever": {"key": "value"}
                                     },
-                                    "python_version": "3.10",
+                                    "python-version": "3.10",
                                 },
                             ],
                         },
@@ -287,7 +287,7 @@ class ConfigTest(TestCase):
                 [
                     RawConfig(
                         (root / "a/b/c/fixit.toml"),
-                        {"enable": ["foo"], "python_version": "3.10"},
+                        {"enable": ["foo"], "python-version": "3.10"},
                     ),
                     RawConfig(
                         (root / "a/b/fixit.toml"),
@@ -295,7 +295,7 @@ class ConfigTest(TestCase):
                     ),
                     RawConfig(
                         (root / "a/fixit.toml"),
-                        {"enable": ["foo"], "python_version": "3.8"},
+                        {"enable": ["foo"], "python-version": "3.8"},
                     ),
                 ],
                 Config(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #340
* #338
* #339

This resolves the inconsistency between docs and implementation on using
`python-version` as the TOML configuration key, rather than
`python_version`, in to follow precedent of PEP 621, etc.