### PR TITLE
Include fake path in config when generating lint rule test cases

### DIFF
--- a/src/fixit/testing.py
+++ b/src/fixit/testing.py
@@ -72,10 +72,10 @@ class LintRuleTestCase(unittest.TestCase):
         test_case: Union[ValidTestCase, InvalidTestCase],
         rule: LintRule,
     ) -> None:
-        config = Config()
         path = Path(
             "valid.py" if isinstance(test_case, ValidTestCase) else "invalid.py"
         )
+        config = Config(path=path)
         source_code = _dedent(test_case.code)
         runner = LintRunner(path, source_code.encode())
         reports = list(runner.collect_violations([rule], config))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #341

This fixes testing for rules that depend on metadata providers and repo
managers, by ensuring the config is generated with a file path rather
than the default CWD.

Fixes #311