### PR TITLE
Fix using report() with a Module visitor

### DIFF
--- a/src/fixit/rule.py
+++ b/src/fixit/rule.py
@@ -148,11 +148,16 @@ class LintRule(BatchableCSTVisitor):
         # comments at the start of the file are part of the module header rather than
         # part of the first statement's leading_lines, so we need to look there in case
         # the reported node is part of the first statement.
-        parent = self.get_metadata(ParentNodeProvider, node)
-        if isinstance(parent, Module) and parent.body and parent.body[0] == node:
-            for line in parent.header:
+        if isinstance(node, Module):
+            for line in node.header:
                 if line.comment:
                     yield line.comment.value
+        else:
+            parent = self.get_metadata(ParentNodeProvider, node)
+            if isinstance(parent, Module) and parent.body and parent.body[0] == node:
+                for line in parent.header:
+                    if line.comment:
+                        yield line.comment.value
 
     def ignore_lint(self, node: CSTNode) -> bool:
         """


### PR DESCRIPTION
Currently in `fixit v2.0.0.post1`

calling `self.report()` in a `Module` node visitor like so:
```
    def visit_Module(self, node: cst.Module) -> None:
        self.report(node)
```

resulted in a libcst error where the module node was passed into
`self.get_metadata`:

```
self.get_metadata(ParentNodeProvider, node)
```

I am assuing this fails intentionally in libcst because what is the parent of a module?
Nothing.

It results in this error:

```
python3.10/site-packages/fixit/rule.py:151: in node_comments
    parent = self.get_metadata(ParentNodeProvider, node)
python3.10/site-packages/libcst/_metadata_dependent.py:136: in get_metadata
    value = self.metadata[key][node]
E   KeyError: Module(
E       body=[
E           SimpleStatem
-the rest of the error is just the rest of the module tree-
```

This PR aims to fix that by yielding any comments that exist in
a `module's` header(which is the intention of the `node_comments` function for header comments)

and if the current visitor is not a `module` node
it will check its parent with the `ParentNodeProvider` like it already does.

fixes: [#367](https://github.com/Instagram/Fixit/issues/367)