### PR TITLE
Skip files if no rules are enabled

### DIFF
--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -73,7 +73,8 @@ def fixit_bytes(
     Lint raw bytes content representing a single path, using the given configuration.
 
     Yields :class:`Result` objects for each lint error or exception found, or a single
-    empty result if the file is clean.
+    empty result if the file is clean. A file is considered clean if no lint errors or
+    no rules are enabled for the given path.
     Returns the final :class:`FileContent` including any fixes applied.
 
     Use :func:`capture` to more easily capture return value after iterating through
@@ -82,9 +83,15 @@ def fixit_bytes(
 
     If ``autofix`` is ``True``, all violations with replacements will be applied
     automatically, even if ``False`` is sent back to the generator.
+
     """
     try:
         rules = collect_rules(config)
+
+        if not rules:
+            yield Result(path, violation=None)
+            return None
+
         runner = LintRunner(path, content)
         pending_fixes: List[LintViolation] = []
 

--- a/src/fixit/tests/smoke.py
+++ b/src/fixit/tests/smoke.py
@@ -228,3 +228,51 @@ class SmokeTest(TestCase):
                     sorted(errors[multi]),
                 )
                 self.assertEqual(expected, multi.read_text())
+
+    def test_lint_directory_with_no_rules_enabled(self) -> None:
+        content = dedent(
+            """\
+                import foo
+                import bar
+
+                def func():
+                    value = f"hello world"
+            """
+        )
+        with self.subTest("lint"):
+            with TemporaryDirectory() as td:
+                tdp = Path(td).resolve()
+                path = tdp / "file.py"
+
+                (tdp / "pyproject.toml").write_text(
+                    "[tool.fixit]\ndisable=['fixit.rules']\n"
+                )
+
+                path.write_text(content)
+                result = self.runner.invoke(
+                    main,
+                    ["lint", path.as_posix()],
+                    catch_exceptions=False,
+                )
+
+                self.assertEqual(result.output, "")
+                self.assertEqual(result.exit_code, 0)
+
+        with self.subTest("fix"):
+            with TemporaryDirectory() as td:
+                tdp = Path(td).resolve()
+                path = tdp / "file.py"
+
+                (tdp / "pyproject.toml").write_text(
+                    "[tool.fixit]\ndisable=['fixit.rules']\n"
+                )
+
+                path.write_text(content)
+                result = self.runner.invoke(
+                    main,
+                    ["fix", "--automatic", path.as_posix()],
+                    catch_exceptions=False,
+                )
+
+                self.assertEqual(result.output, "")
+                self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
## Summary
I had suggested on issue https://github.com/Instagram/Fixit/issues/365 that it would be nice to automatically skip a file if no rules were enabled for a given file https://github.com/Instagram/Fixit/issues/365#issuecomment-1678542798.

To avoid unnecessary processing of files if no rules are enabled for a given file the config is now checked before processing a file and if no rules are enabled the file is skipped.

## Test Plan
Two smoke tests have been added to confirm files are skipped if no rules are enabled.
