### PR TITLE
feat: support linting stdin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*.{py,pyi,toml,md}]
-charset = "utf-8"
+charset = utf-8
 end_of_line = lf
 indent_size = 4
 indent_style = space

--- a/docs/guide/commands.rst
+++ b/docs/guide/commands.rst
@@ -46,7 +46,9 @@ The following options are available for all commands:
 ``lint``
 ^^^^^^^^
 
-Lint one or more paths, and print a list of lint errors.
+Lint one or more paths, and print a list of lint errors. If "-" is given as the
+first path, then the second given path will be used for configuration lookup
+and error messages, and the input read from STDIN.
 
 .. code:: console
 
@@ -60,7 +62,10 @@ Lint one or more paths, and print a list of lint errors.
 ``fix``
 ^^^^^^^
 
-Lint one or more paths, and apply suggested fixes.
+Lint one or more paths, and apply suggested fixes. If "-" is given as the
+first path, then the second given path will be used for configuration lookup,
+the input read from STDIN, and the fixed output printed to STDOUT (ignoring
+:attr:`--interactive`).
 
 .. code:: console
 

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -165,7 +165,7 @@ def fix(
     if not paths:
         paths = [Path.cwd()]
 
-    is_stdin = paths[0] and str(paths[0]) == "-"
+    is_stdin = bool(paths[0] and str(paths[0]) == "-")
     interactive = interactive and not is_stdin
     autofix = not interactive
     exit_code = 0

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -32,6 +32,8 @@ from packaging.version import Version
 
 T = TypeVar("T")
 
+STDIN = Path("-")
+
 CodeRange
 CodePosition
 

--- a/src/fixit/tests/smoke.py
+++ b/src/fixit/tests/smoke.py
@@ -109,6 +109,32 @@ class SmokeTest(TestCase):
                     expected_format, path.read_text(), "unexpected file output"
                 )
 
+            with self.subTest("linting via stdin"):
+                result = self.runner.invoke(
+                    main,
+                    ["lint", "-", path.as_posix()],
+                    input=content,
+                    catch_exceptions=False,
+                )
+
+                self.assertNotEqual(result.output, "")
+                self.assertNotEqual(result.exit_code, 0)
+                self.assertRegex(
+                    result.output,
+                    r"file\.py@\d+:\d+ NoRedundantFString: .+ \(has autofix\)",
+                )
+
+            with self.subTest("fixing with formatting via stdin"):
+                result = self.runner.invoke(
+                    main,
+                    ["fix", "-", path.as_posix()],
+                    input=content,
+                    catch_exceptions=False,
+                )
+
+                self.assertEqual(result.exit_code, 0)
+                self.assertEqual(expected_format, result.output, "unexpected stdout")
+
     def test_this_file_is_clean(self) -> None:
         path = Path(__file__).resolve().as_posix()
         result = self.runner.invoke(main, ["lint", path], catch_exceptions=False)


### PR DESCRIPTION
Similarly for `fixit fix`. The API is [inspired by Prettier](https://prettier.io/docs/en/cli.html#--stdin-filepath).

## Summary
Related to #122 but does not fully resolve it. It supports a lint-as-you-type workflow, whereas only a lint-on-save workflow could be supported before. Full resolution of #122 would require #387.

## Test Plan
Extended smoke tests.