### PR TITLE
feat: add `fixit lsp` subcommand

### DIFF
--- a/docs/guide/commands.rst
+++ b/docs/guide/commands.rst
@@ -92,7 +92,7 @@ the input read from STDIN, and the fixed output printed to STDOUT (ignoring
 
 Start the language server providing IDE features over
 `LSP <https://microsoft.github.io/language-server-protocol/>`__.
-This command is only available if installed with the `lsp` extra (e.g.
+This command is only available if installed with the ``lsp`` extras (e.g.
 ``pip install fixit[lsp]``).  See :ref:`IDE Integrations <ide_integrations>`
 for more details.
 

--- a/docs/guide/commands.rst
+++ b/docs/guide/commands.rst
@@ -84,12 +84,17 @@ the input read from STDIN, and the fixed output printed to STDOUT (ignoring
 
     Show applied fixes in unified diff format when applied automatically.
 
+
+.. _lsp_command:
+
 ``lsp``
 ^^^^^^^
 
 Start the language server providing IDE features over
 `LSP <https://microsoft.github.io/language-server-protocol/>`__.
-This command is only available if installed with the `lsp` extra.
+This command is only available if installed with the `lsp` extra (e.g.
+``pip install fixit[lsp]``).  See :ref:`IDE Integrations <ide_integrations>`
+for more details.
 
 .. code:: console
 

--- a/docs/guide/commands.rst
+++ b/docs/guide/commands.rst
@@ -84,6 +84,33 @@ the input read from STDIN, and the fixed output printed to STDOUT (ignoring
 
     Show applied fixes in unified diff format when applied automatically.
 
+``lsp``
+^^^^^^^
+
+Start the language server providing IDE features over
+`LSP <https://microsoft.github.io/language-server-protocol/>`__.
+This command is only available if installed with the `lsp` extra.
+
+.. code:: console
+
+    $ fixit lsp [--stdio | --tcp PORT | --ws PORT]
+
+.. attribute:: --stdio
+
+    Serve LSP over stdio. *default*
+
+.. attribute:: --tcp
+
+    Serve LSP over TCP on PORT.
+
+.. attribute:: --ws
+
+    Serve LSP over WebSocket on PORT.
+
+.. attribute:: --debounce-interval
+
+    Delay in seconds for server-side debounce. *default: 0.5*
+
 
 ``test``
 ^^^^^^^^

--- a/docs/guide/integrations.rst
+++ b/docs/guide/integrations.rst
@@ -1,3 +1,5 @@
+.. _integrations:
+
 Integrations
 ------------
 

--- a/docs/guide/integrations.rst
+++ b/docs/guide/integrations.rst
@@ -1,6 +1,45 @@
 Integrations
 ------------
 
+IDE
+^^^
+
+Fixit can be used to lint as you type as well as to format files.
+
+To get this functionality, install the `lsp` extra, e.g.
+`pip install fixit[lsp]`, then set up an LSP client to launch and connect to
+the Fixit LSP server (``fixit lsp``). Examples of client setup:
+
+- VSCode: `Generic LSP Client <https://github.com/llllvvuu/vscode-glspc>`_:
+
+.. code:: json
+
+    {
+      "glspc.languageId": "python",
+      "glspc.serverCommand": "fixit",
+      "glspc.serverCommandArguments": ["lsp"],
+      "glspc.pathPrepend": "/path/to/python/3.11.4/bin/",
+    }
+
+- Neovim: `nvim-lspconfig <https://github.com/neovim/nvim-lspconfig>`_:
+
+.. code:: lua
+
+      require("lspconfig.configs").fixit = {
+        default_config = {
+          cmd = { "fixit", "lsp" },
+          filetypes = { "python" },
+          root_dir = require("lspconfig").util.root_pattern(
+            "pyproject.toml", "setup.py", "requirements.txt", ".git",
+          ),
+          single_file_support = true,
+        },
+      }
+
+      lspconfig.fixit.setup({})
+
+- `Other IDEs <https://microsoft.github.io/language-server-protocol/implementors/tools/>`_
+
 pre-commit
 ^^^^^^^^^^
 

--- a/docs/guide/integrations.rst
+++ b/docs/guide/integrations.rst
@@ -1,14 +1,19 @@
 Integrations
 ------------
 
+.. _ide_integrations:
+
 IDE
 ^^^
 
 Fixit can be used to lint as you type as well as to format files.
 
-To get this functionality, install the `lsp` extra, e.g.
-`pip install fixit[lsp]`, then set up an LSP client to launch and connect to
-the Fixit LSP server (``fixit lsp``). Examples of client setup:
+To get this functionality, install the ``lsp`` extras (e.g.
+``pip install fixit[lsp]``) then set up an LSP client to launch and connect to
+the Fixit LSP server. See the :ref:`lsp command <lsp_command>` for command
+usage details.
+
+Examples of client setup:
 
 - VSCode: `Generic LSP Client <https://github.com/llllvvuu/vscode-glspc>`_:
 

--- a/docs/guide/quickstart.rst
+++ b/docs/guide/quickstart.rst
@@ -18,6 +18,10 @@ If you want to customize the list of enabled rules, either to add new rules
 or disable others, see the :ref:`Configuration Guide <configuration>` for
 details and options available.
 
+Fixit offers multiple integrations, including pre-commit actions and LSP support
+for VSCode and other editors. See the :ref:`Integrations Guide <integrations>`
+for details.
+
 If you are upgrading from previous versions of Fixit, look at the
 :ref:`Upgrade Guide <upgrade>` for a list of changes and tools to assist with
 migrating to the latest version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,11 @@ dev = [
     "ufmt == 2.5.1",
     "usort == 1.0.8.post1",
 ]
-pretty = [
-    "rich >= 12.6.0",
-]
 lsp = [
     "pygls[ws] >= 1.0.2",
+]
+pretty = [
+    "rich >= 12.6.0",
 ]
 
 [project.scripts]
@@ -99,7 +99,7 @@ exclude = [
 ]
 
 [tool.hatch.envs.all]
-features = ["dev", "docs", "pretty"]
+features = ["dev", "docs", "lsp", "pretty"]
 
 [tool.hatch.envs.default]
 features = ["dev", "lsp", "pretty"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ dev = [
 pretty = [
     "rich >= 12.6.0",
 ]
+lsp = [
+    "pygls[ws] >= 1.0.2",
+]
 
 [project.scripts]
 fixit = "fixit.cli:main"
@@ -99,7 +102,7 @@ exclude = [
 features = ["dev", "docs", "pretty"]
 
 [tool.hatch.envs.default]
-features = ["dev", "pretty"]
+features = ["dev", "lsp", "pretty"]
 
 [tool.hatch.envs.default.scripts]
 test = "python -m fixit.tests"

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -220,7 +220,7 @@ def lsp(
     tcp: Optional[int],
     ws: Optional[int],
     debounce_interval: float,
-):
+) -> None:
     """
     Start server for:
     https://microsoft.github.io/language-server-protocol/

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -15,7 +15,7 @@ from fixit import __version__
 
 from .api import fixit_paths, print_result
 from .config import collect_rules, generate_config, parse_rule
-from .ftypes import Config, Options, QualifiedRule, Tags
+from .ftypes import Config, LSPOptions, Options, QualifiedRule, Tags
 from .rule import LintRule
 from .testing import generate_lint_rule_test_cases
 from .util import capture
@@ -201,6 +201,40 @@ def fix(
 
     splash(visited, dirty, autofixes, fixed)
     ctx.exit(exit_code)
+
+
+@main.command()
+@click.pass_context
+@click.option("--stdio", type=bool, default=True, help="Serve LSP over stdio")
+@click.option("--tcp", type=int, help="Port to serve LSP over")
+@click.option("--ws", type=int, help="Port to serve WS over")
+@click.option(
+    "--debounce-interval",
+    type=float,
+    default=LSPOptions.debounce_interval,
+    help="Delay in seconds for server-side debounce",
+)
+def lsp(
+    ctx: click.Context,
+    stdio: bool,
+    tcp: Optional[int],
+    ws: Optional[int],
+    debounce_interval: float,
+):
+    """
+    Start server for:
+    https://microsoft.github.io/language-server-protocol/
+    """
+    from .lsp import LSP
+
+    main_options = ctx.obj
+    lsp_options = LSPOptions(
+        tcp=tcp,
+        ws=ws,
+        stdio=stdio,
+        debounce_interval=debounce_interval,
+    )
+    LSP(main_options, lsp_options).start()
 
 
 @main.command()

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -184,6 +184,18 @@ class Options:
 
 
 @dataclass
+class LSPOptions:
+    """
+    Command-line options to affect LSP runtime behavior
+    """
+
+    tcp: Optional[int]
+    ws: Optional[int]
+    stdio: bool = True
+    debounce_interval: float = 0.5
+
+
+@dataclass
 class Config:
     """
     Materialized configuration valid for processing a single file.

--- a/src/fixit/lsp.py
+++ b/src/fixit/lsp.py
@@ -1,0 +1,190 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import threading
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable, cast, Dict, Generator, List, Optional, TypeVar
+
+import pygls.uris as Uri
+
+from lsprotocol.types import (
+    Diagnostic,
+    DiagnosticSeverity,
+    DidChangeTextDocumentParams,
+    DidOpenTextDocumentParams,
+    DocumentFormattingParams,
+    Position,
+    Range,
+    TEXT_DOCUMENT_DID_CHANGE,
+    TEXT_DOCUMENT_DID_OPEN,
+    TEXT_DOCUMENT_FORMATTING,
+    TextEdit,
+)
+from pygls.server import LanguageServer
+
+from fixit import __version__
+from fixit.util import capture
+
+from .api import fixit_bytes
+from .config import generate_config
+from .ftypes import Config, FileContent, LSPOptions, Options, Result
+
+
+class LSP:
+    """
+    Server for the Language Server Protocol.
+    Provides diagnostics as you type, and exposes a formatter.
+    https://microsoft.github.io/language-server-protocol/
+    """
+
+    def __init__(self, fixit_options: Options, lsp_options: LSPOptions) -> None:
+        self.fixit_options = fixit_options
+        self.lsp_options = lsp_options
+
+        self._config_cache: Dict[Path, Config] = {}
+
+        # separate debounce timer per URI so that linting one URI
+        # doesn't cancel linting another
+        self._validate_uri: Dict[str, Callable[[int], None]] = {}
+
+        self.lsp = LanguageServer("fixit-lsp", __version__)
+        # `partial` since `pygls` can register functions but not methods
+        self.lsp.feature(TEXT_DOCUMENT_DID_OPEN)(partial(self.on_did_open))
+        self.lsp.feature(TEXT_DOCUMENT_DID_CHANGE)(partial(self.on_did_change))
+        self.lsp.feature(TEXT_DOCUMENT_FORMATTING)(partial(self.format))
+
+    def load_config(self, path: Path) -> Config:
+        """
+        Cached fetch of fixit.toml(s) for fixit_bytes.
+        """
+        if path not in self._config_cache:
+            self._config_cache[path] = generate_config(path, options=self.fixit_options)
+        return self._config_cache[path]
+
+    def diagnostic_generator(
+        self, uri: str, autofix=False
+    ) -> Optional[Generator[Result, bool, Optional[FileContent]]]:
+        """
+        LSP wrapper (provides document state from `pygls`) for `fixit_bytes`.
+        """
+        path = Uri.to_fs_path(uri)
+        if not path:
+            return None
+        path = Path(path)
+
+        return fixit_bytes(
+            path,
+            self.lsp.workspace.get_document(uri).source.encode(),
+            autofix=autofix,
+            config=self.load_config(path),
+        )
+
+    def _validate(self, uri: str, version: int) -> None:
+        """
+        Effect: publishes Fixit diagnostics to the LSP client.
+        """
+        generator = self.diagnostic_generator(uri)
+        if not generator:
+            return
+        diagnostics = []
+        for result in generator:
+            violation = result.violation
+            if not violation:
+                continue
+            diagnostic = Diagnostic(
+                Range(
+                    Position(  # LSP is 0-indexed; fixit line numbers are 1-indexed
+                        violation.range.start.line - 1, violation.range.start.column
+                    ),
+                    Position(violation.range.end.line - 1, violation.range.end.column),
+                ),
+                violation.message,
+                severity=DiagnosticSeverity.Warning,
+                code=violation.rule_name,
+                source="fixit",
+            )
+            diagnostics.append(diagnostic)
+        self.lsp.publish_diagnostics(uri, diagnostics, version=version)
+
+    def validate(self, uri: str, version: int) -> None:
+        """
+        Effect: may publish Fixit diagnostics to the LSP client after a debounce delay.
+        """
+        if uri not in self._validate_uri:
+            self._validate_uri[uri] = debounce(self.lsp_options.debounce_interval)(
+                partial(self._validate, uri)
+            )
+        self._validate_uri[uri](version)
+
+    def on_did_open(self, params: DidOpenTextDocumentParams) -> None:
+        self.validate(params.text_document.uri, params.text_document.version)
+
+    def on_did_change(self, params: DidChangeTextDocumentParams) -> None:
+        self.validate(params.text_document.uri, params.text_document.version)
+
+    def format(self, params: DocumentFormattingParams) -> Optional[List[TextEdit]]:
+        generator = self.diagnostic_generator(params.text_document.uri, autofix=True)
+        if generator is None:
+            return None
+
+        captured = capture(generator)
+        for _ in captured:
+            pass
+        formatted_content = captured.result
+        if not formatted_content:
+            return None
+
+        doc = self.lsp.workspace.get_document(params.text_document.uri)
+        entire_range = Range(
+            start=Position(line=0, character=0),
+            end=Position(line=len(doc.lines) - 1, character=len(doc.lines[-1])),
+        )
+
+        return [TextEdit(new_text=formatted_content.decode(), range=entire_range)]
+
+    def start(self) -> None:
+        """
+        Effect: occupies the specified I/O channels.
+        """
+        if self.lsp_options.ws:
+            self.lsp.start_ws("localhost", self.lsp_options.ws)
+        if self.lsp_options.tcp:
+            self.lsp.start_tcp("localhost", self.lsp_options.tcp)
+        if self.lsp_options.stdio:
+            self.lsp.start_io()
+
+
+VoidFunction = TypeVar("VoidFunction", bound=Callable[..., None])
+
+
+class Debouncer:
+    def __init__(self, f: Callable[..., Any], interval: float) -> None:
+        self.f = f
+        self.interval = interval
+        self._timer: Optional[threading.Timer] = None
+        self._lock = threading.Lock()
+
+    def __call__(self, *args, **kwargs) -> None:
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+            self._timer = threading.Timer(self.interval, self.f, args, kwargs)
+            self._timer.start()
+
+
+def debounce(interval: float):
+    """
+    Wait `interval` seconds before calling `f`, and cancel if called again.
+    The decorated function will return None immediately,
+    ignoring the delayed return value of `f`.
+    """
+
+    def decorator(f: VoidFunction) -> VoidFunction:
+        if interval <= 0:
+            return f
+        return cast(VoidFunction, Debouncer(f, interval))
+
+    return decorator


### PR DESCRIPTION
resolves #387 #122

Note: easier to read in unified view since it's new code.
Note: uses the popular [pygls](https://github.com/openlawlibrary/pygls) ([Apache 2.0](https://github.com/openlawlibrary/pygls/blob/main/LICENSE.txt)) implementation of the protocol.

https://github.com/Instagram/Fixit/assets/5601392/2dcd7447-431e-49a9-a383-aa424d4fbc6b

## Summary

Support for:
- [x] `textDocument/didOpen`, `textDocument/didChange` -> `textDocument/publishDiagnostics`
- [x] `textDocument/formatting`

Not supported yet

- [ ] `textDocument/codeAction`, `workspace/executeCommand` (possibly blocked on #352 #358)
- [ ] `workspace/didChangeWatchedFiles` to invalidate the config cache
- [ ] VSCode frontend (documented [Generic LSP Client](https://github.com/llllvvuu/vscode-glspc) for now but probably want Fixit-specific extension/branding)

If this PR gets merged I will create follow-up issues for these items.

## Test Plan

Added new smoke test for the new `fixit lsp` subcommand.