### PR TITLE
Make CollectionError pickleable

### DIFF
--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -69,6 +69,9 @@ class CollectionError(RuntimeError):
         super().__init__(msg)
         self.rule = rule
 
+    def __reduce__(self):
+        return type(self), (*self.args, self.rule)
+
 
 def is_rule(obj: Type[T]) -> bool:
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #401
* #400

CollectionError could not be unpickled because the default
`Exception.__reduce__` implementation does not include any
attributes/values that weren't passed to the superclass constructor,
resulting in a failure when unpickling the exception in the parent
class because the `rule` argument wasn't given.

This updates the class to add a custom `__reduce__` that fixes the
ability to pickle/unpickle the class correctly, fixing the primary
issue with exceptions during linting resulting in broken process
pools.

Fix #381