### PR TITLE
Demonstrate fixme comments that are not being respected

### DIFF
--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -5,6 +5,7 @@
 
 from pathlib import Path
 from textwrap import dedent, indent
+from typing import Optional, Sequence, Tuple
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -282,7 +283,7 @@ class RuleTest(TestCase):
         ):
             idx += 1
             content = dedent(code).encode("utf-8")
-            with self.subTest(f"test case {idx}"):
+            with self.subTest(f"test ignore {idx}"):
                 runner = LintRunner(Path("fake.py"), content)
                 violations = list(
                     runner.collect_violations([ExerciseReportRule()], Config())

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -73,6 +73,13 @@ class ExerciseReportRule(LintRule):
 
     def visit_ClassDef(self, node: cst.ClassDef) -> bool:
         self.report(node, "class def")
+        for d in node.decorators:
+            self.report(d, "class decorator")
+        return False
+
+    def visit_FunctionDef(self, node: cst.FunctionDef) -> bool:
+        if node.name.value == "problem":
+            self.report(node, "problem function")
         return False
 
     def visit_Pass(self, node: cst.Pass) -> bool:
@@ -279,6 +286,119 @@ class RuleTest(TestCase):
                 """,
                 "class def",
                 (5, 0),
+            ),
+            (
+                # before function decorators
+                """
+                    import sys
+
+                    # lint-fixme: ExerciseReport
+                    @contextmanager
+                    def problem():
+                        yield True
+                """,
+                None,
+                None,
+            ),
+            (
+                # after function decorators
+                """
+                    import sys
+
+                    @contextmanager
+                    # lint-fixme: ExerciseReport
+                    def problem():
+                        yield True
+                """,
+                None,
+                None,
+            ),
+            (
+                # before class decorators
+                """
+                    import dataclasses
+
+                    # lint-fixme: ExerciseReport
+                    @dataclasses.dataclass
+                    class C:
+                        value = 1
+                """,
+                None,
+                None,
+            ),
+            (
+                # after class decorators
+                """
+                    import dataclasses
+
+                    @dataclasses.dataclass
+                    # lint-fixme: ExerciseReport
+                    class C:
+                        value = 1
+                """,
+                None,
+                None,
+            ),
+            (
+                # above comprehension
+                """
+                    # lint-fixme: ExerciseReport
+                    [... for _ in range(1)]
+                """,
+                None,
+                None,
+            ),
+            (
+                # inside comprehension
+                """
+                    [
+                        # lint-fixme: ExerciseReport
+                        ... for _ in range(1)
+                    ]
+                """,
+                None,
+                None,
+            ),
+            (
+                # after comprehension
+                """
+                    [... for _ in range(1)]  # lint-fixme: ExerciseReport
+                """,
+                None,
+                None,
+            ),
+            (
+                # trailing inline comprehension
+                """
+                    [
+                        ... for _ in range(1)  # lint-fixme: ExerciseReport
+                    ]
+                """,
+                None,
+                None,
+            ),
+            (
+                # before list element
+                """
+                    [
+                        # lint-fixme: ExerciseReport
+                        ...,
+                        None,
+                    ]
+                """,
+                None,
+                None,
+            ),
+            (
+                # trailing list element
+                """
+                    [
+                        ...,  # lint-fixme: ExerciseReport
+                        None,
+                    ]
+                """,
+                None,
+                None,
             ),
         ):
             idx += 1


### PR DESCRIPTION
## Summary

## Test Plan

Failing tests have been added to demonstrate (most of) the bugs reported in #405. I have not been able to add one for the function definition problem because there are cases in this test that need to define functions without errors, so I can't just report `functionDef`.