### PR TITLE
make format of fixit's terminal output configurable

### DIFF
--- a/docs/guide/commands.rst
+++ b/docs/guide/commands.rst
@@ -43,6 +43,16 @@ The following options are available for all commands:
     two tags.
 
 
+.. attribute:: --output-format / -o FORMAT_TYPE
+
+    Override how Fixit prints violations to the terminal.
+
+    See :attr:`output-format` for available formats.
+
+.. attribute:: --output-template TEMPLATE
+
+    Override the python formatting template to use with ``output-format = 'custom'``.
+
 ``lint``
 ^^^^^^^^
 
@@ -72,7 +82,7 @@ the input read from STDIN, and the fixed output printed to STDOUT (ignoring
     $ fixit fix [--interactive | --automatic [--diff]] [PATH ...]
 
 .. attribute:: --interactive / -i
-    
+
     Interactively prompt the user to apply or decline suggested fixes for
     each auto-fix available. *default*
 

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -165,6 +165,13 @@ The main configuration table.
     - ``fixit``: Fixit's default output format.
     - ``vscode``: A format that provides clickable paths for Visual Studio Code.
 
+    .. note::
+
+        The default output format is planned to change to ``vscode`` in
+        the next feature release, expected as part of ``v2.3`` or ``v3.0``.
+        If you are sensitive to output formats changing, specify your preferred
+        format in your project configs accordingly.
+
 .. attribute:: output-template
     :type: str
 

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -152,40 +152,43 @@ The main configuration table.
     :class:`~fixit.Formatter` interface.
 
 .. attribute:: output-format
-    :type: Literal['fixit', 'vscode', 'custom']
+    :type: str
 
     Choose one of the presets for terminal output formatting.
-    Fixit only reads this option from the current working directory or from an explicitly specified config file.
-
-    Defaults to fixit's output style.
+    This option is inferred based on the current working directory or from
+    an explicity specified config file -- subpath overrides will be ignored.
 
     Can be one of:
 
-    - ``fixit``: Fixit's default output format
-    - ``vscode``: A format that works well with Visual Studio Code
-    - ``custom``: Use your own format via :attr:`output-template` config option
+    - ``custom``: Specify your own format using the :attr:`output-template`
+      option below.
+    - ``fixit``: Fixit's default output format.
+    - ``vscode``: A format that provides clickable paths for Visual Studio Code.
 
 .. attribute:: output-template
     :type: str
 
     Sets the format of output printed to terminal.
     Python formatting is used in the background to fill in data.
-    Only active with ``output-format = 'custom'``.
-    Like :attr:`output-format`, this config variable is only read from the current working directory.
+    Only active with :attr:`output-format` set to ``custom``.
 
-    Defaults to ``{path}@{start_line}:{start_col} {rule_name}: {message}``
+    This option is inferred based on the current working directory or from
+    an explicity specified config file -- subpath overrides will be ignored.
 
     Supported variables:
 
+    - ``message``: Message emitted by the applied rule.
+
     - ``path``: Path to affected file.
 
-    - ``start_line``: Start line of affected code lines.
+    - ``result``: Raw :class:`~fixit.Result` object.
+
+    - ``rule_name``: Name of the applied rule.
 
     - ``start_col``: Start column of affected code.
 
-    - ``rule_name``: Name of the applied rule
+    - ``start_line``: Start line of affected code.
 
-    - ``message``: Message emitted by the applied rule
 
 .. _rule-options:
 

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -117,26 +117,6 @@ The main configuration table.
     to the root configuration, to :attr:`sys.path` when attempting to import
     and materialize any enabled lint rules.
 
-
-.. attribute:: output-format
-    :type: str
-
-    Sets the format of output printed to terminal. Can only be set in root config (see :attr:`enable-root-import`).
-
-    Defaults to ``{path}@{start_line}:{start_col} {rule_name}: {message}``
-
-    Supported variables:
-
-    - ``path``: Path to affected file.
-
-    - ``start_line``: Start line of affected code lines.
-
-    - ``start_col``: Start column of affected code.
-
-    - ``rule_name``: Name of the applied rule
-
-    - ``message``: Message emitted by the applied rule
-
 .. attribute:: python-version
     :type: str
 
@@ -171,6 +151,41 @@ The main configuration table.
     Alternative formatting styles can be added by implementing the
     :class:`~fixit.Formatter` interface.
 
+.. attribute:: output-format
+    :type: Literal['fixit', 'vscode', 'custom']
+
+    Choose one of the presets for terminal output formatting.
+    Fixit only reads this option from the current working directory or from an explicitly specified config file.
+
+    Defaults to fixit's output style.
+
+    Can be one of:
+
+    - ``fixit``: Fixit's default output format
+    - ``vscode``: A format that works well with Visual Studio Code
+    - ``custom``: Use your own format via :attr:`output-template` config option
+
+.. attribute:: output-template
+    :type: str
+
+    Sets the format of output printed to terminal.
+    Python formatting is used in the background to fill in data.
+    Only active with ``output-format = 'custom'``.
+    Like :attr:`output-format`, this config variable is only read from the current working directory.
+
+    Defaults to ``{path}@{start_line}:{start_col} {rule_name}: {message}``
+
+    Supported variables:
+
+    - ``path``: Path to affected file.
+
+    - ``start_line``: Start line of affected code lines.
+
+    - ``start_col``: Start column of affected code.
+
+    - ``rule_name``: Name of the applied rule
+
+    - ``message``: Message emitted by the applied rule
 
 .. _rule-options:
 

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -99,7 +99,7 @@ The main configuration table.
 
     .. code-block:: toml
 
-        root = True
+        root = true
         enable-root-import = "src"
         enable = ["orange.rules"]
 
@@ -117,6 +117,26 @@ The main configuration table.
     to the root configuration, to :attr:`sys.path` when attempting to import
     and materialize any enabled lint rules.
 
+
+.. attribute:: output-format
+    :type: str
+
+    Sets the format of output printed to terminal. Can only be set in root config (see :attr:`enable-root-import`).
+
+    Defaults to ``{path}@{start_line}:{start_col} {rule_name}: {message}``
+
+    Supported variables:
+
+    - ``path``: Path to affected file.
+
+    - ``start_line``: Start line of affected code lines.
+
+    - ``start_col``: Start column of affected code.
+
+    - ``rule_name``: Name of the applied rule
+
+    - ``message``: Message emitted by the applied rule
+
 .. attribute:: python-version
     :type: str
 
@@ -129,7 +149,7 @@ The main configuration table.
     .. code-block:: toml
 
         python-version = "3.10"
-    
+
     Defaults to the currently active version of Python.
     Set to empty string ``""`` to disable target version checking.
 

--- a/docs/guide/integrations.rst
+++ b/docs/guide/integrations.rst
@@ -79,5 +79,5 @@ see the `pre-commit docs <https://pre-commit.com/#pre-commit-configyaml---hooks>
 
 VSCode
 ^^^^^^
-For integration with Visual Studio Code setting ``output-format`` to ``{path}:{start_line}:{start_col} {rule_name}: {message}`` is recommended.
-That way VSCode opens the editor at the right position when clicking on filenames in Fixit's terminal output.
+For better integration with Visual Studio Code setting ``output-format`` can be set to ``vscode``.
+That way VSCode opens the editor at the right position when clicking on code locations in Fixit's terminal output.

--- a/docs/guide/integrations.rst
+++ b/docs/guide/integrations.rst
@@ -75,3 +75,9 @@ your repository.
 
 To read more about how you can customize your pre-commit configuration,
 see the `pre-commit docs <https://pre-commit.com/#pre-commit-configyaml---hooks>`__.
+
+
+VSCode
+^^^^^^
+For integration with Visual Studio Code setting ``output-format`` to ``{path}:{start_line}:{start_col} {rule_name}: {message}`` is recommended.
+That way VSCode opens the editor at the right position when clicking on filenames in Fixit's terminal output.

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -8,21 +8,24 @@ import sys
 import traceback
 from functools import partial
 from pathlib import Path
-from typing import Generator, Iterable, List, Literal, Optional, Union
+from typing import Generator, Iterable, List, Optional
 
 import click
 import trailrunner
 from moreorless.click import echo_color_precomputed_diff
 
-from .config import (
-    collect_rules,
-    generate_config,
-    output_formats_templates,
-    OutputFormatTypeInput,
-)
+from .config import collect_rules, generate_config, output_formats_templates
 from .engine import LintRunner
 from .format import format_module
-from .ftypes import Config, FileContent, LintViolation, Options, Result, STDIN
+from .ftypes import (
+    Config,
+    FileContent,
+    LintViolation,
+    Options,
+    OutputFormatTypeInput,
+    Result,
+    STDIN,
+)
 
 LOG = logging.getLogger(__name__)
 

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -14,15 +14,15 @@ import click
 from fixit import __version__
 
 from .api import fixit_paths, print_result
-from .config import (
-    collect_rules,
-    generate_config,
-    get_cwd_config,
-    output_formats_templates,
+from .config import collect_rules, generate_config, get_cwd_config, parse_rule
+from .ftypes import (
+    Config,
+    LSPOptions,
+    Options,
     OutputFormatTypeInput,
-    parse_rule,
+    QualifiedRule,
+    Tags,
 )
-from .ftypes import Config, LSPOptions, Options, QualifiedRule, Tags
 from .rule import LintRule
 from .testing import generate_lint_rule_test_cases
 from .util import capture

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -123,8 +123,9 @@ def lint(
     autofixes = 0
     for result in fixit_paths(paths, options=options):
         visited.add(result.path)
-
-        if print_result(result, show_diff=diff):
+        if print_result(
+            result, show_diff=diff, output_format=result.config.output_format
+        ):
             dirty.add(result.path)
             if result.violation:
                 exit_code |= 1
@@ -183,7 +184,12 @@ def fix(
         visited.add(result.path)
         # for STDIN, we need STDOUT to equal the fixed content, so
         # move everything else to STDERR
-        if print_result(result, show_diff=interactive or diff, stderr=is_stdin):
+        if print_result(
+            result,
+            show_diff=interactive or diff,
+            stderr=is_stdin,
+            output_format=result.config.output_format,
+        ):
             dirty.add(result.path)
             if autofix and result.violation and result.violation.autofixable:
                 autofixes += 1

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -10,7 +10,7 @@ import pkgutil
 import platform
 import sys
 from contextlib import contextmanager, ExitStack
-from functools import reduce
+
 from pathlib import Path
 from types import ModuleType
 from typing import (
@@ -20,7 +20,6 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -62,7 +61,7 @@ FIXIT_LOCAL_MODULE = "fixit.local"
 CWD_CONFIG_KEYS = ("output-format", "output-template")
 
 
-output_formats_templates: dict[OutputFormatType, str] = {
+output_formats_templates: Dict[OutputFormatType, str] = {
     "fixit": "{path}@{start_line}:{start_col} {rule_name}: {message}",
     "vscode": "{path}:{start_line}:{start_col} {rule_name}: {message}",
 }

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -10,6 +10,7 @@ import pkgutil
 import platform
 import sys
 from contextlib import contextmanager, ExitStack
+from functools import reduce
 from pathlib import Path
 from types import ModuleType
 from typing import (
@@ -19,6 +20,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -34,9 +36,12 @@ from packaging.version import InvalidVersion, Version
 from .format import FORMAT_STYLES
 from .ftypes import (
     Config,
+    CwdConfig,
     is_collection,
     is_sequence,
     Options,
+    OutputFormatType,
+    OutputFormatTypeInput,
     QualifiedRule,
     QualifiedRuleRegex,
     RawConfig,
@@ -54,7 +59,14 @@ else:
 
 FIXIT_CONFIG_FILENAMES = ("fixit.toml", ".fixit.toml", "pyproject.toml")
 FIXIT_LOCAL_MODULE = "fixit.local"
-DEFAULT_OUTPUT_FORMAT = "{path}@{start_line}:{start_col} {rule_name}: {message}"
+CWD_CONFIG_KEYS = ("output-format", "output-template")
+
+
+output_formats_templates: dict[OutputFormatType, str] = {
+    "fixit": "{path}@{start_line}:{start_col} {rule_name}: {message}",
+    "vscode": "{path}:{start_line}:{start_col} {rule_name}: {message}",
+}
+
 
 log = logging.getLogger(__name__)
 
@@ -403,7 +415,6 @@ def merge_configs(
     rule_options: RuleOptionsTable = {}
     target_python_version: Optional[Version] = Version(platform.python_version())
     target_formatter: Optional[str] = None
-    output_format: str = DEFAULT_OUTPUT_FORMAT
 
     def process_subpath(
         subpath: Path,
@@ -416,7 +427,6 @@ def merge_configs(
     ) -> None:
         nonlocal target_python_version
         nonlocal target_formatter
-        nonlocal output_format
 
         subpath = subpath.resolve()
         try:
@@ -467,13 +477,6 @@ def merge_configs(
         if data.pop("root", False):
             root = config.path.parent
 
-        if value := data.pop("output-format", False):
-            if root != config.path.parent:
-                raise ConfigError(
-                    "output-format not allowed in non-root configs", config=config
-                )
-            output_format = value
-
         if value := data.pop("enable-root-import", False):
             if root != config.path.parent:
                 raise ConfigError(
@@ -523,7 +526,8 @@ def merge_configs(
             )
 
         for key in data.keys():
-            log.warning("unknown configuration option %r", key)
+            if key not in CWD_CONFIG_KEYS:
+                log.warning("unknown configuration option %r", key)
 
     return Config(
         path=path,
@@ -534,7 +538,6 @@ def merge_configs(
         options=rule_options,
         python_version=target_python_version,
         formatter=target_formatter,
-        output_format=output_format,
     )
 
 
@@ -564,5 +567,37 @@ def generate_config(
         if options.rules:
             config.enable = list(options.rules)
             config.disable = []
+
+    return config
+
+
+def get_cwd_config(options: Optional[Options] = None) -> CwdConfig:
+    config = CwdConfig()
+    if options and options.config_file:
+        paths = [options.config_file]
+    else:
+        cwd = Path.cwd()
+        paths = locate_configs(cwd, cwd)
+
+    raw_configs = read_configs(paths)
+
+    output_format: Optional[OutputFormatTypeInput] = None
+    output_template: Optional[str] = None
+    for raw_config in raw_configs:
+
+        if output_format is None:
+            output_format = raw_config.data.get("output-format")
+        if output_template is None:
+            output_template = raw_config.data.get("output-template")
+
+    config.output_format = output_format or "fixit"
+    config.output_template = output_template or output_formats_templates["fixit"]
+
+    if options:
+        if options.output_format:
+            config.output_format = options.output_format
+
+        if options.output_template:
+            config.output_template = options.output_template
 
     return config

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -220,12 +220,18 @@ class Config:
     )
     tags: Tags = field(default_factory=Tags)
 
+    output_format: str = ""
+
     # post-run processing
     formatter: Optional[str] = None
 
     def __post_init__(self) -> None:
+        from .config import DEFAULT_OUTPUT_FORMAT
+
         self.path = self.path.resolve()
         self.root = self.root.resolve()
+        if not self.output_format:
+            self.output_format = DEFAULT_OUTPUT_FORMAT
 
 
 @dataclass
@@ -266,5 +272,6 @@ class Result:
     """
 
     path: Path
+    config: Config
     violation: Optional[LintViolation]
     error: Optional[Tuple[Exception, str]] = None

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -14,7 +14,6 @@ from typing import (
     Container,
     ContextManager,
     Dict,
-    get_args,
     Iterable,
     List,
     Literal,
@@ -243,7 +242,7 @@ class CwdConfig:
     output_format: OutputFormatTypeInput = "fixit"
     output_template: str = ""
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         from .config import output_formats_templates
 
         self.output_template = output_formats_templates["fixit"]

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -557,7 +557,7 @@ class ConfigTest(TestCase):
             )
             self.assertListEqual([UseTypesFromTyping], rules)
 
-    def test_cwd_config(self):
+    def test_cwd_config(self) -> None:
         prev_cwd = Path.cwd()
         os.chdir(str(self.outer))
         try:
@@ -593,7 +593,7 @@ class ConfigTest(TestCase):
         finally:
             os.chdir(str(prev_cwd))
 
-    def test_format_output(self):
+    def test_format_output(self) -> None:
         prev_cwd = Path.cwd()
         try:
             os.chdir(str(self.tdp))

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 from dataclasses import asdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -14,10 +13,18 @@ from unittest import TestCase
 from click.testing import CliRunner
 
 from .. import config
-
 from ..cli import main
-from ..ftypes import Config, QualifiedRule, RawConfig, Tags, Version
+from ..ftypes import (
+    Config,
+    Options,
+    OutputFormat,
+    QualifiedRule,
+    RawConfig,
+    Tags,
+    Version,
+)
 from ..rule import LintRule
+from ..util import chdir
 
 
 class ConfigTest(TestCase):
@@ -345,10 +352,11 @@ class ConfigTest(TestCase):
                 self.assertEqual(expected, actual)
 
     def test_generate_config(self) -> None:
-        for name, path, root, expected in (
+        for name, path, root, options, expected in (
             (
                 "inner",
                 self.inner / "foo.py",
+                None,
                 None,
                 Config(
                     path=self.inner / "foo.py",
@@ -364,6 +372,7 @@ class ConfigTest(TestCase):
             (
                 "outer",
                 self.outer / "foo.py",
+                None,
                 None,
                 Config(
                     path=self.outer / "foo.py",
@@ -384,6 +393,7 @@ class ConfigTest(TestCase):
                 "outer with root",
                 self.outer / "foo.py",
                 self.outer,
+                None,
                 Config(
                     path=self.outer / "foo.py",
                     root=self.outer,
@@ -394,6 +404,7 @@ class ConfigTest(TestCase):
             (
                 "other",
                 self.tdp / "other" / "foo.py",
+                None,
                 None,
                 Config(
                     path=self.tdp / "other" / "foo.py",
@@ -416,6 +427,7 @@ class ConfigTest(TestCase):
                 "root",
                 self.tdp / "foo.py",
                 None,
+                None,
                 Config(
                     path=self.tdp / "foo.py",
                     root=self.tdp,
@@ -425,9 +437,25 @@ class ConfigTest(TestCase):
                     python_version=Version("3.8"),
                 ),
             ),
+            (
+                "root with options",
+                self.tdp / "foo.py",
+                None,
+                Options(output_format=OutputFormat.custom, output_template="foo-bar"),
+                Config(
+                    path=self.tdp / "foo.py",
+                    root=self.tdp,
+                    enable_root_import=True,
+                    enable=[QualifiedRule("fixit.rules"), QualifiedRule("more.rules")],
+                    disable=[QualifiedRule("fixit.rules.SomethingSpecific")],
+                    python_version=Version("3.8"),
+                    output_format=OutputFormat.custom,
+                    output_template="foo-bar",
+                ),
+            ),
         ):
             with self.subTest(name):
-                actual = config.generate_config(path, root)
+                actual = config.generate_config(path, root, options=options)
                 self.assertDictEqual(asdict(expected), asdict(actual))
 
     def test_invalid_config(self) -> None:
@@ -557,48 +585,15 @@ class ConfigTest(TestCase):
             )
             self.assertListEqual([UseTypesFromTyping], rules)
 
-    def test_cwd_config(self) -> None:
-        prev_cwd = Path.cwd()
-        os.chdir(str(self.outer))
-        try:
-
-            cwd_config = config.get_cwd_config()
-            self.assertEqual("fixit", cwd_config.output_format)
-
-            (self.inner / "fixit.toml").write_text(
-                "[tool.fixit]\noutput-format = 'custom'"
-            )
-
-            cwd_config = config.get_cwd_config()
-            self.assertEqual("fixit", cwd_config.output_format)
-
-            (self.tdp / "pyproject.toml").write_text(
-                "[tool.fixit]\noutput-format = 'custom'"
-            )
-
-            cwd_config = config.get_cwd_config()
-            self.assertEqual("fixit", cwd_config.output_format)
-
-            (self.outer / "pyproject.toml").write_text(
-                "[tool.fixit]\noutput-format = 'vscode'"
-            )
-
-            cwd_config = config.get_cwd_config()
-            self.assertEqual("vscode", cwd_config.output_format)
-
-            os.chdir(str(self.inner))
-
-            cwd_config = config.get_cwd_config()
-            self.assertEqual("custom", cwd_config.output_format)
-        finally:
-            os.chdir(str(prev_cwd))
-
     def test_format_output(self) -> None:
-        prev_cwd = Path.cwd()
-        try:
-            os.chdir(str(self.tdp))
+        with chdir(self.tdp):
             (self.tdp / "pyproject.toml").write_text(
-                "[tool.fixit]\noutput-format = 'vscode'\n"
+                dedent(
+                    """
+                    [tool.fixit]
+                    output-format = "vscode"
+                    """
+                )
             )
 
             runner = CliRunner(mix_stderr=False)
@@ -624,7 +619,13 @@ class ConfigTest(TestCase):
                 "{path}|{start_line}|{start_col} {rule_name}: {message}"
             )
             (self.tdp / "pyproject.toml").write_text(
-                f"[tool.fixit]\noutput-format = 'custom'\noutput-template = '{custom_output_format}'"
+                dedent(
+                    f"""
+                    [tool.fixit]
+                    output-format = 'custom'
+                    output-template = '{custom_output_format}'
+                    """
+                )
             )
 
             with self.subTest("linting custom"):
@@ -639,5 +640,25 @@ class ConfigTest(TestCase):
                 )
                 self.assertRegex(result.output, custom_output_format_regex)
 
-        finally:
-            os.chdir(str(prev_cwd))
+            with self.subTest("override output-format"):
+                result = runner.invoke(
+                    main,
+                    ["--output-format", "vscode", "lint", filepath.as_posix()],
+                    catch_exceptions=True,
+                )
+                self.assertRegex(result.output, output_format_regex)
+
+            with self.subTest("override output-template"):
+                result = runner.invoke(
+                    main,
+                    [
+                        "--output-template",
+                        "file {path} line {start_line} rule {rule_name}",
+                        "lint",
+                        filepath.as_posix(),
+                    ],
+                    catch_exceptions=True,
+                )
+                self.assertRegex(
+                    result.output, r"file .*f_string\.py line \d+ rule UseFstring"
+                )

--- a/src/fixit/util.py
+++ b/src/fixit/util.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import sys
 from contextlib import contextmanager
 from pathlib import Path
@@ -87,3 +88,13 @@ def append_sys_path(path: Path) -> Generator[None, None, None]:
     # already there: do nothing, and don't remove it later
     else:
         yield
+
+
+@contextmanager
+def chdir(path: Path) -> Generator[None, None, None]:
+    cwd = Path.cwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
This PR makes the format of Fixit's output configurable.
I hope I got everything right 😸 

fixes #397 
closes #305 
