### PR TITLE
Support lint ignore directives in more places

### DIFF
--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -5,7 +5,6 @@
 
 from pathlib import Path
 from textwrap import dedent, indent
-from typing import Optional, Sequence, Tuple
 from unittest import TestCase
 from unittest.mock import MagicMock
 

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -5,6 +5,7 @@
 
 from pathlib import Path
 from textwrap import dedent, indent
+from typing import Optional, Sequence, Tuple
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -282,7 +283,7 @@ class RuleTest(TestCase):
         ):
             idx += 1
             content = dedent(code).encode("utf-8")
-            with self.subTest(f"test case {idx}"):
+            with self.subTest(f"test ignore {idx}"):
                 runner = LintRunner(Path("fake.py"), content)
                 violations = list(
                     runner.collect_violations([ExerciseReportRule()], Config())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #442
* __->__ #441

Adds logic to `LintRule.node_comments()` looking for directives in more
locations relative to the current node:

- trailing inline comments after commas
- preceding and trailing comments inside brackets
- preceding comments before/after decorators for classes and functions

In addition, to better support suppressions for decorators themselves,
the logic to break upward searching until reaching a `leading_lines`
node has been modified to exclude `Decorator` nodes which have their own
leading lines that aren't used for the first decorator on a class.

Based on code examples reported in #413