### PR TITLE
fix(lsp): bump pygls from 1.0.2 to 1.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     "usort == 1.0.8.post1",
 ]
 lsp = [
-    "pygls[ws] >= 1.0.2",
+    "pygls[ws] ~= 1.3.1",
 ]
 pretty = [
     "rich >= 12.6.0",


### PR DESCRIPTION
## Summary
It turns out that >=1.0.2 was pulling in 1.1.0 for me and I was unknowingly using features introduced in that version in #390, which I didn't catch until my dependency resolution changed.

## Test Plan
The project should build with the lowest specified version and tests should still pass.