### PR TITLE
Pre-generate configs for the tree of files

### DIFF
--- a/src/fixit/rules/fixit.toml
+++ b/src/fixit/rules/fixit.toml
@@ -1,0 +1,5 @@
+[tool.fixit]
+root = false
+disable=[
+    "fixit.rules",
+]


### PR DESCRIPTION
Experiments with pre-generating all config files in a top-down manner and sharing that with each sub-process, so that we don't have to re-generate a config-per-file.
