### PR TITLE
Lintrule collections abc

### DIFF
--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -244,12 +244,13 @@ Built-in Rules
 
 .. class:: DeprecatedABCImport
 
-    Checks for the use of the deprecated collections ABC import. Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`.
-    This `LintRule` checks that all ABC imports are under `collections.abc`.
+    Checks for the use of the deprecated collections ABC import. Since python 3.3,
+    the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`.
+    These ABCs are import errors starting in Python 3.10.
 
     .. attribute:: MESSAGE
 
-        Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`. This was a deprecation warning up until 3.9, and is an import error in 3.10.
+        ABCs must be imported from collections.abc
 
     .. attribute:: AUTOFIX
         :type: Yes

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -245,7 +245,7 @@ Built-in Rules
 .. class:: DeprecatedABCImport
 
     Checks for the use of the deprecated collections ABC import. Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`.
-    This `LintRule` checks that all ABC imports are under `collections.ABC`.
+    This `LintRule` checks that all ABC imports are under `collections.abc`.
 
     .. attribute:: MESSAGE
 

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -22,6 +22,7 @@ Built-in Rules
 - :class:`CollapseIsinstanceChecks`
 - :class:`ComparePrimitivesByEqual`
 - :class:`CompareSingletonPrimitivesByIs`
+- :class:`DeprecatedABCImport`
 - :class:`DeprecatedUnittestAsserts`
 - :class:`NoAssertTrueForComparisons`
 - :class:`NoInheritFromObject`
@@ -240,6 +241,46 @@ Built-in Rules
 
             # suggested fix
             x is not False
+
+.. class:: DeprecatedABCImport
+
+    Checks for the use of the deprecated collections ABC import. Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`.
+    This `LintRule` checks that all ABC imports are under `collections.ABC`.
+
+    .. attribute:: MESSAGE
+
+        Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`. This was a deprecation warning up until 3.9, and is an import error in 3.10.
+
+    .. attribute:: AUTOFIX
+        :type: Yes
+
+    .. attribute:: PYTHON_VERSION
+        :type: '>= 3.3'
+
+    .. attribute:: VALID
+
+        .. code:: python
+
+            from collections.abc import Container
+        .. code:: python
+
+            from collections.abc import Container, Hashable
+
+    .. attribute:: INVALID
+
+        .. code:: python
+
+            from collections import Container
+
+            # suggested fix
+            from collections.abc import Container
+
+        .. code:: python
+
+            from collections import Container, Hashable
+
+            # suggested fix
+            from collections.abc import Container, Hashable
 
 .. class:: DeprecatedUnittestAsserts
 

--- a/src/fixit/rules/collections_abc_import_update.py
+++ b/src/fixit/rules/collections_abc_import_update.py
@@ -3,8 +3,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import List, Optional, Union
+
 import libcst as cst
 from libcst._nodes.expression import Attribute, Name
+from libcst._nodes.statement import (
+    BaseCompoundStatement,
+    ImportAlias,
+    ImportFrom,
+    SimpleStatementLine,
+)
 
 from fixit import Invalid, LintRule, Valid
 
@@ -79,26 +87,48 @@ class DeprecatedABCImport(LintRule):
             "import collections.Container",
             expected_replacement="import collections.abc.Container",
         ),
-        # No expected replacement for this one since it would require updating
-        # the parent node in the `visit`. This is due to the need of splitting
-        # the import statement into two separate import statements.
         Invalid(
             "from collections import defaultdict, Container",
+            expected_replacement="from collections import defaultdict\nfrom collections.abc import Container",
+        ),
+        Invalid(
+            "from collections import defaultdict\nfrom collections import Container",
+            expected_replacement="from collections import defaultdict\nfrom collections.abc import Container",
         ),
     ]
 
+    def __init__(self) -> None:
+        super().__init__()
+        # If the module needs to updated
+        self.update_module = False
+
     def visit_ImportFrom(self, node: cst.ImportFrom) -> None:
+        """
+        This catches the `from collections import <ABC>` cases
+        """
+        # Get imports in this statement
         import_names = (
-            [name.name.value in ABCS for name in node.names]
+            [name.name.value for name in node.names]
             if type(node.names) is tuple
-            else [False]
+            else []
         )
-        if node.module and node.module.value == "collections" and any(import_names):
+        # Filter the imports for ABC imports
+        import_names_in_abc = [name in ABCS for name in import_names]
+        if (
+            node.module
+            and node.module.value == "collections"
+            and any(import_names_in_abc)
+        ):
             # Replacing the case where there are ABCs mixed with non-ABCs requires
-            # updating the parent of the `node`. This is due to the need of splitting
-            # the import statement into two separate import statements.
-            if not all(import_names):
-                self.report(node)
+            # splitting a single import statement into two separate imports. This
+            # cannot be achieved in this method and is offloaded to leaving the module.
+            if not all(import_names_in_abc):
+                # We set this variable which triggers the `self.report` to be called
+                # in `leave_Module`. We report in the `leave_Module`
+                # so that we can add an additional `SimpleStatementLine` for the new
+                # import
+                self.update_module = True
+                self.imports_names = import_names
             else:
                 self.report(
                     node,
@@ -110,7 +140,96 @@ class DeprecatedABCImport(LintRule):
                     ),
                 )
 
+    def get_import_from(
+        self, node: Union[SimpleStatementLine, BaseCompoundStatement]
+    ) -> Optional[ImportFrom]:
+        """
+        Iterate over a Statement Sequence and return a Statement if it is a
+        `cst.ImportFrom` statement.
+        """
+        if isinstance(node, SimpleStatementLine):
+            for statement in node.body:
+                # Get the imports in this statement
+                import_names = (
+                    [
+                        name.name.value if isinstance(name, ImportAlias) else None
+                        for name in statement.names
+                    ]
+                    if isinstance(statement, ImportFrom)
+                    and isinstance(statement.names, tuple)
+                    else []
+                )
+                if (
+                    isinstance(statement, ImportFrom)
+                    and statement.module
+                    and statement.module.value == "collections"
+                    # Ensure the imports in this statement are the ones we are looking for
+                    and set(import_names).intersection(set(self.imports_names))
+                ):
+                    return statement
+
+        return None
+
+    def leave_Module(self, node: cst.Module) -> None:
+        """
+        While leaving the module, check if we need to split up imports.
+        """
+        if self.update_module:
+            # Filter the ABCs and non-ABCs
+            abcs: List[str] = []
+            non_abcs: List[str] = []
+            for name in self.imports_names:
+                (non_abcs, abcs)[name in ABCS].append(name)
+
+            node_body = list(node.body)
+
+            # Iterate over the module to find bad imports
+            for idx, statement in enumerate(node_body):
+                # Find if the statement is the one we are searching for
+                import_statement = self.get_import_from(statement)
+                if import_statement:
+                    # Remove the original import statement
+                    node_body.remove(statement)
+                    # Add the non ABC imports
+                    node_body.insert(
+                        idx,
+                        cst.SimpleStatementLine(
+                            body=(
+                                cst.ImportFrom(
+                                    module=cst.Name(value="collections"),
+                                    names=[
+                                        cst.ImportAlias(name=cst.Name(value=imp))
+                                        for imp in non_abcs
+                                    ],
+                                ),
+                            )
+                        ),
+                    )
+                    # Add the ABC imports
+                    node_body.insert(
+                        idx + 1,
+                        cst.SimpleStatementLine(
+                            body=(
+                                cst.ImportFrom(
+                                    module=cst.Attribute(
+                                        value=cst.Name(value="collections"),
+                                        attr=cst.Name(value="abc"),
+                                    ),
+                                    names=[
+                                        cst.ImportAlias(name=cst.Name(value=imp))
+                                        for imp in abcs
+                                    ],
+                                ),
+                            )
+                        ),
+                    )
+
+            self.report(node, replacement=node.with_changes(body=node_body))
+
     def visit_ImportAlias(self, node: cst.ImportAlias) -> None:
+        """
+        This catches the straight `import collections.<ABC>` cases.
+        """
         if (
             type(node.name) is Attribute
             and type(node.name.value) is Name

--- a/src/fixit/rules/collections_abc_import_update.py
+++ b/src/fixit/rules/collections_abc_import_update.py
@@ -53,7 +53,7 @@ ABCS = frozenset(
 class DeprecatedABCImport(LintRule):
     """
     Checks for the use of the deprecated collections ABC import. Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`.
-    This `LintRule` checks that all ABC imports are under `collections.ABC`.
+    This `LintRule` checks that all ABC imports are under `collections.abc`.
     """
 
     TASKS = {"safe"}
@@ -228,7 +228,7 @@ class DeprecatedABCImport(LintRule):
 
     def visit_ImportAlias(self, node: cst.ImportAlias) -> None:
         """
-        This catches the straight `import collections.<ABC>` cases.
+        This catches the `import collections.<ABC>` cases.
         """
         if (
             type(node.name) is Attribute

--- a/src/fixit/rules/collections_abc_import_update.py
+++ b/src/fixit/rules/collections_abc_import_update.py
@@ -1,0 +1,114 @@
+import libcst as cst
+
+from fixit import Invalid, LintRule, Valid
+from libcst._nodes.expression import Attribute
+
+
+# The ABCs that have been moved to `collections.abc`
+ABCS = frozenset({
+        "AsyncGenerator",
+        "AsyncIterable",
+        "AsyncIterator",
+        "Awaitable",
+        "Buffer",
+        "ByteString",
+        "Callable",
+        "Collection",
+        "Container",
+        "Coroutine",
+        "Generator",
+        "Hashable",
+        "ItemsView",
+        "Iterable",
+        "Iterator",
+        "KeysView",
+        "Mapping",
+        "MappingView",
+        "MutableMapping",
+        "MutableSequence",
+        "MutableSet",
+        "Reversible",
+        "Sequence",
+        "Set",
+        "Sized",
+        "ValuesView",
+    })
+
+
+class DeprecatedABCImport(LintRule):
+    TASKS = {"safe"}
+    MESSAGE = "Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`. This was a deprecation warning up until 3.9, and is an import error in 3.10."
+    PYTHON_VERSION = ">= 3.3"
+
+    VALID: list[Valid | str] = [
+        Valid("from collections.abc import Container"),
+        Valid("from collections.abc import Container, Hashable"),
+        Valid("from collections.abc import (Container, Hashable)"),
+        Valid("from collections import defaultdict"),
+        Valid("from collections import abc"),
+        Valid("import collections"),
+        Valid("import collections.abc"),
+    ]
+    INVALID: list[Invalid | str] = [
+        Invalid(
+            "from collections import Container",
+            expected_replacement="from collections.abc import Container",
+        ),
+        Invalid(
+            "from collections import Container, Hashable",
+            expected_replacement="from collections.abc import Container, Hashable",
+        ),
+        Invalid(
+            "from collections import (Container, Hashable)",
+            expected_replacement="from collections.abc import (Container, Hashable)",
+        ),
+        Invalid(
+            "import collections.Container",
+            expected_replacement="import collections.abc.Container",
+        ),
+        # No expected replacement for this one since it would require updating
+        # the parent node in the `visit`.
+        Invalid(
+            "from collections import defaultdict, Container",
+        ),
+    ]
+
+    def visit_ImportFrom(self, node: cst.ImportFrom) -> None:
+        import_names = [name.name.value in ABCS for name in node.names]
+        # This catches the `form collections import <ABC>` case.
+        if (
+            node.module
+            and node.module.value == "collections"
+            and any(import_names)
+        ):
+            # Replacing the case where there are ABCs mixed with non-ABCs requires
+            # updating the parent of the `node`.
+            if not all(import_names):
+                self.report(node)
+            else:
+                self.report(
+                    node,
+                    replacement=node.with_changes(
+                        module=cst.Attribute(
+                            value=cst.Name(value="collections"), attr=cst.Name(value="abc")
+                        )
+                    ),
+                )
+
+    def visit_ImportAlias(self, node: cst.ImportAlias) -> None:
+        if (
+            type(node.name) is Attribute
+            and node.name.value.value == "collections"
+            and node.name.attr.value in ABCS
+        ):
+            self.report(
+                node,
+                replacement=node.with_changes(
+                    name=cst.Attribute(
+                        value=cst.Attribute(
+                            value=cst.Name(value="collections"), attr=cst.Name(value="abc")
+                        ),
+                        attr=node.name.attr
+                    )
+                ),
+            )

--- a/src/fixit/rules/collections_abc_import_update.py
+++ b/src/fixit/rules/collections_abc_import_update.py
@@ -68,7 +68,8 @@ class DeprecatedABCImport(LintRule):
             expected_replacement="import collections.abc.Container",
         ),
         # No expected replacement for this one since it would require updating
-        # the parent node in the `visit`.
+        # the parent node in the `visit`. This is due to the need of splitting
+        # the import statement into two separate import statements.
         Invalid(
             "from collections import defaultdict, Container",
         ),
@@ -76,14 +77,14 @@ class DeprecatedABCImport(LintRule):
 
     def visit_ImportFrom(self, node: cst.ImportFrom) -> None:
         import_names = [name.name.value in ABCS for name in node.names]
-        # This catches the `form collections import <ABC>` case.
         if (
             node.module
             and node.module.value == "collections"
             and any(import_names)
         ):
             # Replacing the case where there are ABCs mixed with non-ABCs requires
-            # updating the parent of the `node`.
+            # updating the parent of the `node`. This is due to the need of splitting
+            # the import statement into two separate import statements.
             if not all(import_names):
                 self.report(node)
             else:

--- a/src/fixit/rules/collections_abc_import_update.py
+++ b/src/fixit/rules/collections_abc_import_update.py
@@ -48,6 +48,7 @@ class DeprecatedABCImport(LintRule):
         Valid("from collections import abc"),
         Valid("import collections"),
         Valid("import collections.abc"),
+        Valid("import collections.abc.Container"),
     ]
     INVALID: list[Invalid | str] = [
         Invalid(

--- a/src/fixit/rules/collections_abc_import_update.py
+++ b/src/fixit/rules/collections_abc_import_update.py
@@ -1,11 +1,12 @@
 import libcst as cst
+from libcst._nodes.expression import Attribute
 
 from fixit import Invalid, LintRule, Valid
-from libcst._nodes.expression import Attribute
 
 
 # The ABCs that have been moved to `collections.abc`
-ABCS = frozenset({
+ABCS = frozenset(
+    {
         "AsyncGenerator",
         "AsyncIterable",
         "AsyncIterator",
@@ -32,7 +33,8 @@ ABCS = frozenset({
         "Set",
         "Sized",
         "ValuesView",
-    })
+    }
+)
 
 
 class DeprecatedABCImport(LintRule):
@@ -77,11 +79,7 @@ class DeprecatedABCImport(LintRule):
 
     def visit_ImportFrom(self, node: cst.ImportFrom) -> None:
         import_names = [name.name.value in ABCS for name in node.names]
-        if (
-            node.module
-            and node.module.value == "collections"
-            and any(import_names)
-        ):
+        if node.module and node.module.value == "collections" and any(import_names):
             # Replacing the case where there are ABCs mixed with non-ABCs requires
             # updating the parent of the `node`. This is due to the need of splitting
             # the import statement into two separate import statements.
@@ -92,7 +90,8 @@ class DeprecatedABCImport(LintRule):
                     node,
                     replacement=node.with_changes(
                         module=cst.Attribute(
-                            value=cst.Name(value="collections"), attr=cst.Name(value="abc")
+                            value=cst.Name(value="collections"),
+                            attr=cst.Name(value="abc"),
                         )
                     ),
                 )
@@ -108,9 +107,10 @@ class DeprecatedABCImport(LintRule):
                 replacement=node.with_changes(
                     name=cst.Attribute(
                         value=cst.Attribute(
-                            value=cst.Name(value="collections"), attr=cst.Name(value="abc")
+                            value=cst.Name(value="collections"),
+                            attr=cst.Name(value="abc"),
                         ),
-                        attr=node.name.attr
+                        attr=node.name.attr,
                     )
                 ),
             )

--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -88,6 +88,10 @@ class DeprecatedABCImport(LintRule):
             expected_replacement="import collections.abc.Container",
         ),
         Invalid(
+            "import collections.Container as cont",
+            expected_replacement="import collections.abc.Container as cont",
+        ),
+        Invalid(
             "from collections import defaultdict, Container",
             expected_replacement="from collections import defaultdict\nfrom collections.abc import Container",
         ),

--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -52,12 +52,12 @@ ABCS = frozenset(
 
 class DeprecatedABCImport(LintRule):
     """
-    Checks for the use of the deprecated collections ABC import. Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`.
-    This `LintRule` checks that all ABC imports are under `collections.abc`.
+    Checks for the use of the deprecated collections ABC import. Since python 3.3,
+    the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`.
+    These ABCs are import errors starting in Python 3.10.
     """
 
-    TASKS = {"safe"}
-    MESSAGE = "Since python 3.3, the Collections Abstract Base Classes (ABC) have been moved to `collections.abc`. This was a deprecation warning up until 3.9, and is an import error in 3.10."
+    MESSAGE = "ABCs must be imported from collections.abc"
     PYTHON_VERSION = ">= 3.3"
 
     VALID = [

--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -8,11 +8,6 @@ from typing import List, Optional, Union
 import libcst as cst
 
 import libcst.matchers as m
-from libcst._nodes.statement import (
-    BaseCompoundStatement,
-    ImportFrom,
-    SimpleStatementLine,
-)
 
 from fixit import Invalid, LintRule, Valid
 
@@ -147,8 +142,8 @@ class DeprecatedABCImport(LintRule):
                 )
 
     def get_import_from(
-        self, node: Union[SimpleStatementLine, BaseCompoundStatement]
-    ) -> Optional[ImportFrom]:
+        self, node: Union[cst.SimpleStatementLine, cst.BaseCompoundStatement]
+    ) -> Optional[cst.ImportFrom]:
         """
         Iterate over a Statement Sequence and return a Statement if it is a
         `cst.ImportFrom` statement.

--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -167,33 +167,16 @@ class DeprecatedABCImport(LintRule):
         Iterate over a Statement Sequence and return a Statement if it is a
         `cst.ImportFrom` statement.
         """
-        if m.matches(
+        imp = m.findall(
             node,
-            m.SimpleStatementLine(
-                body=[
-                    m.ZeroOrMore(),
-                    m.ImportFrom(
-                        module=m.Name("collections"),
-                        names=m.OneOf(
-                            [m.ImportAlias(name=m.Name(n)) for n in self.imports_names]
-                        ),
-                    ),
-                    m.ZeroOrMore(),
-                ]
-            ),
-        ):
-            imp = m.findall(
-                node,
-                m.ImportFrom(
-                    module=m.Name("collections"),
-                    names=m.OneOf(
-                        [m.ImportAlias(name=m.Name(n)) for n in self.imports_names]
-                    ),
+            m.ImportFrom(
+                module=m.Name("collections"),
+                names=m.OneOf(
+                    [m.ImportAlias(name=m.Name(n)) for n in self.imports_names]
                 ),
-            )[0]
-            return imp if isinstance(imp, cst.ImportFrom) else None
-
-        return None
+            ),
+        )
+        return imp[0] if len(imp) > 0 and isinstance(imp[0], cst.ImportFrom) else None
 
     def leave_Module(self, node: cst.Module) -> None:
         """

--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -100,7 +100,9 @@ class DeprecatedABCImport(LintRule):
     def __init__(self) -> None:
         super().__init__()
         # If the module needs to updated
-        self.update_module = False
+        self.update_module: bool = False
+        # The original imports
+        self.imports_names: List[str] = []
 
     def visit_ImportFrom(self, node: cst.ImportFrom) -> None:
         """

--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -238,20 +238,14 @@ class DeprecatedABCImport(LintRule):
         """
         This catches the `import collections.<ABC>` cases.
         """
-        if (
-            m.matches(
-                node,
-                m.ImportAlias(
-                    name=m.Attribute(
-                        value=m.Name("collections"),
-                        attr=m.OneOf(*[m.Name(abc) for abc in ABCS]),
-                    )
-                ),
-            )
-            # This is necessary for the typecheck. Otherwise when replacing the node
-            # and using `attr=node.name.attr`, the type checker will complain since
-            # node.name is `Union[cst.Name | cst.Attribute]`
-            and isinstance(node.name, cst.Attribute)
+        if m.matches(
+            node,
+            m.ImportAlias(
+                name=m.Attribute(
+                    value=m.Name("collections"),
+                    attr=m.OneOf(*[m.Name(abc) for abc in ABCS]),
+                )
+            ),
         ):
             self.report(
                 node,
@@ -261,7 +255,7 @@ class DeprecatedABCImport(LintRule):
                             value=cst.Name(value="collections"),
                             attr=cst.Name(value="abc"),
                         ),
-                        attr=node.name.attr,
+                        attr=cst.ensure_type(node.name, cst.Attribute).attr,
                     )
                 ),
             )


### PR DESCRIPTION
## Summary
Since python 3.3, the Collections Abstract Base Classes (ABC) has been moved to the `collections.abc` module. This lint rule checks and fixes (some) ABC imports from `collections` to `collections.abc`.

## Test Plan
The lint rule has several built in tests that were run using `hatch run test`