### PR TITLE
Allow a targeted (named rule) enable to override a module disable

### DIFF
--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -476,6 +476,24 @@ class ConfigTest(TestCase):
             )
             self.assertListEqual([UseClsInClassmethod], rules)
 
+        with self.subTest("disable builtins"):
+            rules = collect_types(
+                Config(
+                    disable=[QualifiedRule("fixit.rules")],
+                    python_version=None,
+                )
+            )
+            self.assertListEqual([], rules)
+
+        with self.subTest("override broad opt-out"):
+            rules = collect_types(
+                Config(
+                    disable=[QualifiedRule("fixit.rules")],
+                    enable=[QualifiedRule("fixit.rules", "UseClsInClassmethod")],
+                )
+            )
+            self.assertListEqual([UseClsInClassmethod], rules)
+
         with self.subTest("version match"):
             rules = collect_types(
                 Config(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #463

This allows the following configuration to work as a way of disabling
all of the builtin rules except for specific ones:

```
[tool.fixit]
disable = ["fixit.rules"]
enable = ["fixit.rules:UseClsInClassmethod"]
```

Co-authored-by: surge119 <ly.sergio480@gmail.com>