### PR TITLE
Add Logging for Timing Metrics

### DIFF
--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -21,7 +21,7 @@ from .ftypes import (
     Config,
     FileContent,
     LintViolation,
-    LoggerHook,
+    MetricsHook,
     Options,
     OutputFormat,
     Result,
@@ -100,7 +100,7 @@ def fixit_bytes(
     *,
     config: Config,
     autofix: bool = False,
-    logger_hook: Optional[LoggerHook] = None,
+    logger_hook: Optional[MetricsHook] = None,
 ) -> Generator[Result, bool, Optional[FileContent]]:
     """
     Lint raw bytes content representing a single path, using the given configuration.
@@ -155,7 +155,7 @@ def fixit_stdin(
     *,
     autofix: bool = False,
     options: Optional[Options] = None,
-    logger_hook: Optional[LoggerHook] = None,
+    logger_hook: Optional[MetricsHook] = None,
 ) -> Generator[Result, bool, None]:
     """
     Wrapper around :func:`fixit_bytes` for formatting content from STDIN.
@@ -188,7 +188,7 @@ def fixit_file(
     *,
     autofix: bool = False,
     options: Optional[Options] = None,
-    logger_hook: Optional[LoggerHook] = None,
+    logger_hook: Optional[MetricsHook] = None,
 ) -> Generator[Result, bool, None]:
     """
     Lint a single file on disk, detecting and generating appropriate configuration.
@@ -224,7 +224,7 @@ def _fixit_file_wrapper(
     *,
     autofix: bool = False,
     options: Optional[Options] = None,
-    logger_hook: Optional[LoggerHook] = None,
+    logger_hook: Optional[MetricsHook] = None,
 ) -> List[Result]:
     """
     Wrapper because generators can't be pickled or used directly via multiprocessing
@@ -241,7 +241,7 @@ def fixit_paths(
     autofix: bool = False,
     options: Optional[Options] = None,
     parallel: bool = True,
-    logger_hook: Optional[LoggerHook] = None,
+    logger_hook: Optional[MetricsHook] = None,
 ) -> Generator[Result, bool, None]:
     """
     Lint multiple files or directories, recursively expanding each path.

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -21,6 +21,7 @@ from .ftypes import (
     Config,
     FileContent,
     LintViolation,
+    LoggerHook,
     Options,
     OutputFormat,
     Result,
@@ -99,6 +100,7 @@ def fixit_bytes(
     *,
     config: Config,
     autofix: bool = False,
+    logger_hook: Optional[LoggerHook] = None,
 ) -> Generator[Result, bool, Optional[FileContent]]:
     """
     Lint raw bytes content representing a single path, using the given configuration.
@@ -127,7 +129,7 @@ def fixit_bytes(
         pending_fixes: List[LintViolation] = []
 
         clean = True
-        for violation in runner.collect_violations(rules, config):
+        for violation in runner.collect_violations(rules, config, logger_hook):
             clean = False
             fix = yield Result(path, violation)
             if fix or autofix:
@@ -153,6 +155,7 @@ def fixit_stdin(
     *,
     autofix: bool = False,
     options: Optional[Options] = None,
+    logger_hook: Optional[LoggerHook] = None,
 ) -> Generator[Result, bool, None]:
     """
     Wrapper around :func:`fixit_bytes` for formatting content from STDIN.
@@ -169,7 +172,9 @@ def fixit_stdin(
         content: FileContent = sys.stdin.buffer.read()
         config = generate_config(path, options=options)
 
-        updated = yield from fixit_bytes(path, content, config=config, autofix=autofix)
+        updated = yield from fixit_bytes(
+            path, content, config=config, autofix=autofix, logger_hook=logger_hook
+        )
         if autofix:
             sys.stdout.buffer.write(updated or content)
 
@@ -183,6 +188,7 @@ def fixit_file(
     *,
     autofix: bool = False,
     options: Optional[Options] = None,
+    logger_hook: Optional[LoggerHook] = None,
 ) -> Generator[Result, bool, None]:
     """
     Lint a single file on disk, detecting and generating appropriate configuration.
@@ -201,7 +207,9 @@ def fixit_file(
         content: FileContent = path.read_bytes()
         config = generate_config(path, options=options)
 
-        updated = yield from fixit_bytes(path, content, config=config, autofix=autofix)
+        updated = yield from fixit_bytes(
+            path, content, config=config, autofix=autofix, logger_hook=logger_hook
+        )
         if updated and updated != content:
             LOG.info(f"{path}: writing changes to file")
             path.write_bytes(updated)
@@ -212,13 +220,19 @@ def fixit_file(
 
 
 def _fixit_file_wrapper(
-    path: Path, *, autofix: bool = False, options: Optional[Options] = None
+    path: Path,
+    *,
+    autofix: bool = False,
+    options: Optional[Options] = None,
+    logger_hook: Optional[LoggerHook] = None,
 ) -> List[Result]:
     """
     Wrapper because generators can't be pickled or used directly via multiprocessing
     TODO: replace this with some sort of queue or whatever
     """
-    return list(fixit_file(path, autofix=autofix, options=options))
+    return list(
+        fixit_file(path, autofix=autofix, options=options, logger_hook=logger_hook)
+    )
 
 
 def fixit_paths(
@@ -227,6 +241,7 @@ def fixit_paths(
     autofix: bool = False,
     options: Optional[Options] = None,
     parallel: bool = True,
+    logger_hook: Optional[LoggerHook] = None,
 ) -> Generator[Result, bool, None]:
     """
     Lint multiple files or directories, recursively expanding each path.
@@ -276,11 +291,20 @@ def fixit_paths(
             expanded_paths.extend(trailrunner.walk(path))
 
     if is_stdin:
-        yield from fixit_stdin(stdin_path, autofix=autofix, options=options)
+        yield from fixit_stdin(
+            stdin_path, autofix=autofix, options=options, logger_hook=logger_hook
+        )
     elif len(expanded_paths) == 1 or not parallel:
         for path in expanded_paths:
-            yield from fixit_file(path, autofix=autofix, options=options)
+            yield from fixit_file(
+                path, autofix=autofix, options=options, logger_hook=logger_hook
+            )
     else:
-        fn = partial(_fixit_file_wrapper, autofix=autofix, options=options)
+        fn = partial(
+            _fixit_file_wrapper,
+            autofix=autofix,
+            options=options,
+            logger_hook=logger_hook,
+        )
         for _, results in trailrunner.run_iter(expanded_paths, fn):
             yield from results

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -144,7 +144,7 @@ def lint(
     autofixes = 0
     config = generate_config(options=options)
     for result in fixit_paths(
-        paths, options=options, logger_hook=print if options.print_metrics else None
+        paths, options=options, metrics_hook=print if options.print_metrics else None
     ):
         visited.add(result.path)
         if print_result(
@@ -210,7 +210,7 @@ def fix(
             autofix=autofix,
             options=options,
             parallel=False,
-            logger_hook=print if options.print_metrics else None,
+            metrics_hook=print if options.print_metrics else None,
         )
     )
     config = generate_config(options=options)

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -86,6 +86,7 @@ def splash(
     default="",
     help="Python format template to use with output format 'custom'",
 )
+@click.option("--print-metrics", is_flag=True, help="Print metrics of this run")
 def main(
     ctx: click.Context,
     debug: Optional[bool],
@@ -94,6 +95,7 @@ def main(
     rules: str,
     output_format: Optional[OutputFormat],
     output_template: str,
+    print_metrics: bool,
 ) -> None:
     level = logging.WARNING
     if debug is not None:
@@ -113,19 +115,18 @@ def main(
         ),
         output_format=output_format,
         output_template=output_template,
+        print_metrics=print_metrics,
     )
 
 
 @main.command()
 @click.pass_context
 @click.option("--diff", "-d", is_flag=True, help="Show diff of suggested changes")
-@click.option("--metrics", "-m", is_flag=True, help="Print metrics of this run")
 @click.argument("paths", nargs=-1, type=click.Path(path_type=Path))
 def lint(
     ctx: click.Context,
     diff: bool,
     paths: Sequence[Path],
-    metrics: bool,
 ) -> None:
     """
     lint one or more paths and return suggestions
@@ -143,7 +144,7 @@ def lint(
     autofixes = 0
     config = generate_config(options=options)
     for result in fixit_paths(
-        paths, options=options, logger_hook=print if metrics else None
+        paths, options=options, logger_hook=print if options.print_metrics else None
     ):
         visited.add(result.path)
         if print_result(
@@ -174,14 +175,12 @@ def lint(
     help="how to apply fixes; interactive by default unless STDIN",
 )
 @click.option("--diff", "-d", is_flag=True, help="show diff even with --automatic")
-@click.option("--metrics", "-m", is_flag=True, help="Print metrics of this run")
 @click.argument("paths", nargs=-1, type=click.Path(path_type=Path))
 def fix(
     ctx: click.Context,
     interactive: bool,
     diff: bool,
     paths: Sequence[Path],
-    metrics: bool,
 ) -> None:
     """
     lint and autofix one or more files and return results
@@ -211,7 +210,7 @@ def fix(
             autofix=autofix,
             options=options,
             parallel=False,
-            logger_hook=print if metrics else None,
+            logger_hook=print if options.print_metrics else None,
         )
     )
     config = generate_config(options=options)

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -19,8 +19,8 @@ from .ftypes import (
     Config,
     FileContent,
     LintViolation,
-    LoggableMetric,
-    LoggerHook,
+    Metrics,
+    MetricsHook,
     NodeReplacement,
 )
 from .rule import LintRule
@@ -53,17 +53,17 @@ class LintRunner:
         self.path = path
         self.source = source
         self.module: Module = parse_module(source)
-        self.log_event: LoggableMetric = defaultdict(lambda: 0)
+        self.metrics: Metrics = defaultdict(lambda: 0)
 
     def collect_violations(
         self,
         rules: Collection[LintRule],
         config: Config,
-        logger_hook: Optional[LoggerHook] = None,
+        metrics_hook: Optional[MetricsHook] = None,
     ) -> Generator[LintViolation, None, int]:
         """Run multiple `LintRule`s and yield any lint violations.
 
-        The optional `logger_hook` parameter will be called (if provided) after all
+        The optional `metrics_hook` parameter will be called (if provided) after all
         lint rules have finished running, passing in a dictionary of
         ``RuleName.visit_function_name`` -> ``duration in microseconds``.
         """
@@ -76,7 +76,7 @@ class LintRunner:
             finally:
                 duration_us = int(1000 * 1000 * (time.perf_counter() - start))
                 LOG.debug(f"PERF: {name} took {duration_us} µs")
-                self.log_event[name] += duration_us
+                self.metrics[name] += duration_us
 
         metadata_cache: Mapping[ProviderT, object] = {}
         needs_repo_manager: Set[ProviderT] = set()
@@ -111,8 +111,8 @@ class LintRunner:
                     violation = replace(violation, diff=diff)
 
                 yield violation
-        if logger_hook:
-            logger_hook(self.log_event)
+        if metrics_hook:
+            metrics_hook(self.metrics)
 
         return count
 

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -19,9 +19,9 @@ from .ftypes import (
     Config,
     FileContent,
     LintViolation,
+    LoggableMetric,
+    LoggerHook,
     NodeReplacement,
-    Timings,
-    TimingsHook,
 )
 from .rule import LintRule
 
@@ -53,17 +53,17 @@ class LintRunner:
         self.path = path
         self.source = source
         self.module: Module = parse_module(source)
-        self.timings: Timings = defaultdict(lambda: 0)
+        self.log_event: LoggableMetric = defaultdict(lambda: 0)
 
     def collect_violations(
         self,
         rules: Collection[LintRule],
         config: Config,
-        timings_hook: Optional[TimingsHook] = None,
+        logger_hook: Optional[LoggerHook] = None,
     ) -> Generator[LintViolation, None, int]:
         """Run multiple `LintRule`s and yield any lint violations.
 
-        The optional `timings_hook` parameter will be called (if provided) after all
+        The optional `logger_hook` parameter will be called (if provided) after all
         lint rules have finished running, passing in a dictionary of
         ``RuleName.visit_function_name`` -> ``duration in microseconds``.
         """
@@ -76,7 +76,7 @@ class LintRunner:
             finally:
                 duration_us = int(1000 * 1000 * (time.perf_counter() - start))
                 LOG.debug(f"PERF: {name} took {duration_us} µs")
-                self.timings[name] += duration_us
+                self.log_event[name] += duration_us
 
         metadata_cache: Mapping[ProviderT, object] = {}
         needs_repo_manager: Set[ProviderT] = set()
@@ -111,8 +111,8 @@ class LintRunner:
                     violation = replace(violation, diff=diff)
 
                 yield violation
-        if timings_hook:
-            timings_hook(self.timings)
+        if logger_hook:
+            logger_hook(self.log_event)
 
         return count
 

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -46,8 +46,8 @@ RuleOptionsTable = Dict[str, RuleOptions]
 
 NodeReplacement = Union[CSTNodeT, FlattenSentinel[CSTNodeT], RemovalSentinel]
 
-LoggableMetric = Dict[str, Any]
-LoggerHook = Callable[[LoggableMetric], None]
+Metrics = Dict[str, Any]
+MetricsHook = Callable[[Metrics], None]
 
 VisitorMethod = Callable[[CSTNode], None]
 VisitHook = Callable[[str], ContextManager[None]]

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -191,6 +191,7 @@ class Options:
     rules: Sequence[QualifiedRule] = ()
     output_format: Optional[OutputFormat] = None
     output_template: str = ""
+    print_metrics: bool = False
 
 
 @dataclass

--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -46,8 +46,8 @@ RuleOptionsTable = Dict[str, RuleOptions]
 
 NodeReplacement = Union[CSTNodeT, FlattenSentinel[CSTNodeT], RemovalSentinel]
 
-Timings = Dict[str, int]
-TimingsHook = Callable[[Timings], None]
+LoggableMetric = Dict[str, Any]
+LoggerHook = Callable[[LoggableMetric], None]
 
 VisitorMethod = Callable[[CSTNode], None]
 VisitHook = Callable[[str], ContextManager[None]]

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -47,15 +47,15 @@ class RunnerTest(TestCase):
         rule = NoopRule()
         for _ in self.runner.collect_violations([rule], Config()):
             pass  # exhaust the generator
-        self.assertIn("NoopRule.visit_Module", self.runner.timings)
-        self.assertIn("NoopRule.leave_Module", self.runner.timings)
-        self.assertGreaterEqual(self.runner.timings["NoopRule.visit_Module"], 0)
+        self.assertIn("NoopRule.visit_Module", self.runner.log_event)
+        self.assertIn("NoopRule.leave_Module", self.runner.log_event)
+        self.assertGreaterEqual(self.runner.log_event["NoopRule.visit_Module"], 0)
 
     def test_timing_hook(self) -> None:
         rule = NoopRule()
         hook = MagicMock()
         for i, _ in enumerate(
-            self.runner.collect_violations([rule], Config(), timings_hook=hook)
+            self.runner.collect_violations([rule], Config(), logger_hook=hook)
         ):
             if i <= 1:
                 # only called at the end

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -47,15 +47,15 @@ class RunnerTest(TestCase):
         rule = NoopRule()
         for _ in self.runner.collect_violations([rule], Config()):
             pass  # exhaust the generator
-        self.assertIn("NoopRule.visit_Module", self.runner.log_event)
-        self.assertIn("NoopRule.leave_Module", self.runner.log_event)
-        self.assertGreaterEqual(self.runner.log_event["NoopRule.visit_Module"], 0)
+        self.assertIn("NoopRule.visit_Module", self.runner.metrics)
+        self.assertIn("NoopRule.leave_Module", self.runner.metrics)
+        self.assertGreaterEqual(self.runner.metrics["NoopRule.visit_Module"], 0)
 
     def test_timing_hook(self) -> None:
         rule = NoopRule()
         hook = MagicMock()
         for i, _ in enumerate(
-            self.runner.collect_violations([rule], Config(), logger_hook=hook)
+            self.runner.collect_violations([rule], Config(), metrics_hook=hook)
         ):
             if i <= 1:
                 # only called at the end


### PR DESCRIPTION
## Summary
Adds support to the api to invoke a custom logger for timing metrics, and potentially other metrics in the future. Additionally added cli flag to print the timing metrics to stdout.

## Test Plan
`make all`
`hatch run fixit lint -m ./src/fixit/api.py`
```
defaultdict(<function LintRunner.__init__.<locals>.<lambda> at 0x7f7f65a80680>, {'UseFstring.visit_Module': 9, 'DeprecatedABCImport.visit_ImportAlias': 2069, 'DeprecatedABCImport.visit_ImportFrom': 27, 'NoStringTypeAnnotation.visit_ImportFrom': 429, 'RewriteToLiteral.visit_Call': 4417, 'UseFstring.visit_Call': 1381, 'NoAssertTrueForComparisons.visit_Call': 3188, 'UseAssertIn.visit_Call': 7579, 'RewriteToComprehension.visit_Call': 2195, 'UseAssertIsNotNone.visit_Call': 2946, 'DeprecatedUnittestAsserts.visit_Call': 9572, 'UseAsyncSleepInAsyncDef.visit_Call': 14, 'NoRedundantListComprehension.visit_Call': 1601, 'NoRedundantArgumentsSuper.leave_Call': 44, 'UseClsInClassmethod.visit_FunctionDef': 20, 'UseAsyncSleepInAsyncDef.visit_FunctionDef': 6, 'NoStringTypeAnnotation.visit_Annotation': 43, 'ReplaceUnionWithOptional.leave_Annotation': 1747, 'NoStringTypeAnnotation.leave_Annotation': 43, 'NoStringTypeAnnotation.visit_SimpleString': 7, 'AvoidOrInExcept.visit_Try': 410, 'NoStaticIfCondition.visit_If': 1182, 'ComparePrimitivesByEqual.visit_Comparison': 31, 'CompareSingletonPrimitivesByIs.visit_Comparison': 544, 'NoRedundantFString.visit_FormattedString': 239, 'CollapseIsinstanceChecks.visit_BooleanOperation': 362, 'UseAsyncSleepInAsyncDef.leave_FunctionDef': 6, 'NoStringTypeAnnotation.visit_Subscript': 2, 'NoStringTypeAnnotation.leave_Subscript': 2, 'DeprecatedABCImport.leave_Module': 3})
🧼 1 file clean 🧼
```