### PR TITLE
Update DeprecatedABCImport Rule

### DIFF
--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -160,7 +160,7 @@ class DeprecatedABCImport(LintRule):
         Catch instances where a correct import is in a try block with an except block
         that fails over to the deprecated import.
         """
-        # If a try block imports
+        # If a try block imports the correct import, check the except block
         if m.findall(
             node,
             m.ImportFrom(
@@ -173,6 +173,8 @@ class DeprecatedABCImport(LintRule):
                 ],
             ),
         ):
+            # For each handler, ensure it is a ImportError and check that it contains
+            # the deprecated import
             for handler in node.handlers:
                 if (
                     import_nodes := m.findall(

--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -167,7 +167,7 @@ class DeprecatedABCImport(LintRule):
 
     def is_except_block(self, node: cst.CSTNode) -> bool:
         """
-        Check if the node is in an except block - if it is, we know ti ignore it, as it
+        Check if the node is in an except block - if it is, we know to ignore it, as it
         may be a fallback import
         """
         parent = self.get_metadata(ParentNodeProvider, node)


### PR DESCRIPTION
## Summary
In the instance of there being a try except that falls back to the deprecated import, this rule would attempt to change the fallback. An example:
```
try:
    from collections.abc import Container
except ImportError:
    from collections import Container
```
This above example should be valid, but was previously not. Previously, the lint rule would attempt to fix the import in the except block

## Test Plan
make