### PR TITLE
Add More Metrics to be Logged by LoggerHook

### DIFF
--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -115,7 +115,7 @@ class LintRunner:
 
                 yield violation
 
-        self.metrics["ViolationCount.Total"] = count
+        self.metrics["Count.Total"] = count
 
         if metrics_hook:
             metrics_hook(self.metrics)

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -76,7 +76,7 @@ class LintRunner:
             finally:
                 duration_us = int(1000 * 1000 * (time.perf_counter() - start))
                 LOG.debug(f"PERF: {name} took {duration_us} µs")
-                self.metrics[name] += duration_us
+                self.metrics[f"Duration.{name}"] += duration_us
 
         metadata_cache: Mapping[ProviderT, object] = {}
         needs_repo_manager: Set[ProviderT] = set()
@@ -103,10 +103,13 @@ class LintRunner:
         wrapper.visit_batched(rules)
         count = 0
         for rule in rules:
+            self.metrics[f"ViolationCount.{rule.name}"] = len(rule._violations)
+            self.metrics[f"ViolationCountWithReplacement.{rule.name}"] = 0
             for violation in rule._violations:
                 count += 1
 
                 if violation.replacement:
+                    self.metrics[f"ViolationCountWithReplacement.{rule.name}"] += 1
                     diff = diff_violation(self.path, self.module, violation)
                     violation = replace(violation, diff=diff)
 

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 import time
 from collections import defaultdict
 from contextlib import contextmanager
@@ -65,8 +66,16 @@ class LintRunner:
 
         The optional `metrics_hook` parameter will be called (if provided) after all
         lint rules have finished running, passing in a dictionary of
-        ``RuleName.visit_function_name`` -> ``duration in microseconds``.
+        {
+            CLIENT_ID: an optional client id set by environment variable,
+            Duration.RuleName.visit_function_name: duration in microseconds,
+            ViolationCount.RuleName: number of violations,
+            ViolationCountReplacement.RuleName: number of violations with replacements,
+            ViolationCount.Total: total number of violations,
+        }
         """
+
+        self.metrics["CLIENT_ID"] = os.environ.get("FIXIT_CLIENT_ID", "default")
 
         @contextmanager
         def visit_hook(name: str) -> Iterator[None]:

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -103,13 +103,13 @@ class LintRunner:
         wrapper.visit_batched(rules)
         count = 0
         for rule in rules:
-            self.metrics[f"ViolationCount.{rule.name}"] = len(rule._violations)
-            self.metrics[f"ViolationCountWithReplacement.{rule.name}"] = 0
+            self.metrics[f"Count.{rule.name}"] = len(rule._violations)
+            self.metrics[f"FixCount.{rule.name}"] = 0
             for violation in rule._violations:
                 count += 1
 
                 if violation.replacement:
-                    self.metrics[f"ViolationCountWithReplacement.{rule.name}"] += 1
+                    self.metrics[f"FixCount.{rule.name}"] += 1
                     diff = diff_violation(self.path, self.module, violation)
                     violation = replace(violation, diff=diff)
 

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -114,6 +114,9 @@ class LintRunner:
                     violation = replace(violation, diff=diff)
 
                 yield violation
+
+        self.metrics["ViolationCount.Total"] = count
+
         if metrics_hook:
             metrics_hook(self.metrics)
 

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-import os
 import time
 from collections import defaultdict
 from contextlib import contextmanager
@@ -66,16 +65,8 @@ class LintRunner:
 
         The optional `metrics_hook` parameter will be called (if provided) after all
         lint rules have finished running, passing in a dictionary of
-        {
-            CLIENT_ID: an optional client id set by environment variable,
-            Duration.RuleName.visit_function_name: duration in microseconds,
-            ViolationCount.RuleName: number of violations,
-            ViolationCountReplacement.RuleName: number of violations with replacements,
-            ViolationCount.Total: total number of violations,
-        }
+        ``RuleName.visit_function_name`` -> ``duration in microseconds``.
         """
-
-        self.metrics["CLIENT_ID"] = os.environ.get("FIXIT_CLIENT_ID", "default")
 
         @contextmanager
         def visit_hook(name: str) -> Iterator[None]:

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -50,9 +50,9 @@ class RunnerTest(TestCase):
         self.assertIn("Duration.NoopRule.visit_Module", self.runner.metrics)
         self.assertIn("Duration.NoopRule.leave_Module", self.runner.metrics)
         self.assertGreaterEqual(self.runner.metrics["NoopRule.visit_Module"], 0)
-        self.assertIn("ViolationCount.Noop", self.runner.metrics)
-        self.assertIn("ViolationCountWithReplacement.Noop", self.runner.metrics)
-        self.assertIn("ViolationCount.Total", self.runner.metrics)
+        self.assertIn("Count.Noop", self.runner.metrics)
+        self.assertIn("FixCount.Noop", self.runner.metrics)
+        self.assertIn("Count.Total", self.runner.metrics)
 
     def test_timing_hook(self) -> None:
         rule = NoopRule()

--- a/src/fixit/tests/rule.py
+++ b/src/fixit/tests/rule.py
@@ -47,9 +47,12 @@ class RunnerTest(TestCase):
         rule = NoopRule()
         for _ in self.runner.collect_violations([rule], Config()):
             pass  # exhaust the generator
-        self.assertIn("NoopRule.visit_Module", self.runner.metrics)
-        self.assertIn("NoopRule.leave_Module", self.runner.metrics)
+        self.assertIn("Duration.NoopRule.visit_Module", self.runner.metrics)
+        self.assertIn("Duration.NoopRule.leave_Module", self.runner.metrics)
         self.assertGreaterEqual(self.runner.metrics["NoopRule.visit_Module"], 0)
+        self.assertIn("ViolationCount.Noop", self.runner.metrics)
+        self.assertIn("ViolationCountWithReplacement.Noop", self.runner.metrics)
+        self.assertIn("ViolationCount.Total", self.runner.metrics)
 
     def test_timing_hook(self) -> None:
         rule = NoopRule()


### PR DESCRIPTION
## Summary
Added the following metrics:
- Violation Count per Rule per File
- Violation Count per Rule per File with Autofixes
- Total Violation Count per File

## Test Plan
make