### PR TITLE
Improved the Handling of Errors in Rule Collection

### DIFF
--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -231,13 +231,9 @@ def collect_rules(
                 if qualified_rule.name:
                     named_enables |= rules
                 all_rules |= rules
-            except CollectionError as e:
-                log.warning(
-                    f"Collection Error: Failed to collect enabled rules for {config.enable}: {e}"
-                )
             except Exception as e:
                 log.warning(
-                    f"Failed to collect enabled rules for {config.enable}: {e.__class__.__name__}: {e}"
+                    f"Failed to load rules '{qualified_rule.module}': {e.__class__.__name__}: {e}"
                 )
 
         for qualified_rule in config.disable:
@@ -250,13 +246,9 @@ def collect_rules(
                     }
                 )
                 all_rules -= set(disabled_rules)
-            except CollectionError as e:
-                log.warning(
-                    f"Collection Error: Failed to collect disabled rules for {config.enable}: {e}"
-                )
             except Exception as e:
                 log.warning(
-                    f"Failed to collect disabled rules for {config.enable}: {e.__class__.__name__}: {e}"
+                    f"Failed to load rules '{qualified_rule.module}': {e.__class__.__name__}: {e}"
                 )
 
         if config.tags:

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -232,7 +232,13 @@ def collect_rules(
                     named_enables |= rules
                 all_rules |= rules
             except CollectionError as e:
-                log.warning(f"Failed to collect enabled rules for {config.enable}: {e}")
+                log.warning(
+                    f"Collection Error: Failed to collect enabled rules for {config.enable}: {e}"
+                )
+            except Exception as e:
+                log.warning(
+                    f"Failed to collect enabled rules for {config.enable}: {e.__class__.__name__}: {e}"
+                )
 
         for qualified_rule in config.disable:
             try:
@@ -246,7 +252,11 @@ def collect_rules(
                 all_rules -= set(disabled_rules)
             except CollectionError as e:
                 log.warning(
-                    f"Failed to collect disabled rules for {config.enable}: {e}"
+                    f"Collection Error: Failed to collect disabled rules for {config.enable}: {e}"
+                )
+            except Exception as e:
+                log.warning(
+                    f"Failed to collect disabled rules for {config.enable}: {e.__class__.__name__}: {e}"
                 )
 
         if config.tags:

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -232,7 +232,7 @@ def collect_rules(
                     named_enables |= rules
                 all_rules |= rules
             except CollectionError as e:
-                log.error(f"Failed to collect enabled rules for {config.enable}: {e}")
+                log.warning(f"Failed to collect enabled rules for {config.enable}: {e}")
 
         for qualified_rule in config.disable:
             try:
@@ -245,7 +245,9 @@ def collect_rules(
                 )
                 all_rules -= set(disabled_rules)
             except CollectionError as e:
-                log.error(f"Failed to collect disabled rules for {config.enable}: {e}")
+                log.warning(
+                    f"Failed to collect disabled rules for {config.enable}: {e}"
+                )
 
         if config.tags:
             disabled_rules.update(

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -226,20 +226,26 @@ def collect_rules(
             stack.enter_context(append_sys_path(path))
 
         for qualified_rule in config.enable:
-            rules = set(find_rules(qualified_rule))
-            if qualified_rule.name:
-                named_enables |= rules
-            all_rules |= rules
+            try:
+                rules = set(find_rules(qualified_rule))
+                if qualified_rule.name:
+                    named_enables |= rules
+                all_rules |= rules
+            except CollectionError as e:
+                log.error(f"Failed to collect enabled rules for {config.enable}: {e}")
 
         for qualified_rule in config.disable:
-            disabled_rules.update(
-                {
-                    r: "disabled"
-                    for r in find_rules(qualified_rule)
-                    if r not in named_enables
-                }
-            )
-            all_rules -= set(disabled_rules)
+            try:
+                disabled_rules.update(
+                    {
+                        r: "disabled"
+                        for r in find_rules(qualified_rule)
+                        if r not in named_enables
+                    }
+                )
+                all_rules -= set(disabled_rules)
+            except CollectionError as e:
+                log.error(f"Failed to collect disabled rules for {config.enable}: {e}")
 
         if config.tags:
             disabled_rules.update(


### PR DESCRIPTION
## Summary
If a rule defined in a config contains an error or causes an error in Fixit, the linter will raise an unrecoverable error. This PR adds error handling to catch and log those errors as warnings, and continue linting

## Test Plan
```
$ hatch run fixit lint ./src/fixit/api.py
WARNING:fixit.config:Failed to load rules 'fixit.rules': CollectionError: could not import rule(s) fixit.rules
🧼 1 file clean 🧼

# Run with good rules
$ hatch run fixit lint ./src/fixit/api.py
🧼 1 file clean 🧼
```