### PR TITLE
Add validate command

### DIFF
--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -20,8 +20,6 @@ from .rule import LintRule
 from .testing import generate_lint_rule_test_cases
 from .util import capture
 
-log = logging.getLogger(__name__)
-
 
 def splash(
     visited: Set[Path], dirty: Set[Path], autofixes: int = 0, fixed: int = 0
@@ -371,11 +369,8 @@ def validate_config(ctx: click.Context, paths: Sequence[Path]) -> None:
         from pprint import pprint  # type: ignore
 
     for path in paths:
-        path = path.resolve()
-
         try:
-            config = generate_config(path, options=options)
-            enabled = collect_rules(config)
+            collect_rules(generate_config(path.resolve(), options=options))
         except Exception as e:
             pprint(f"Invalid config: {e.__class__.__name__}: {e}")
             exit(-1)

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -356,7 +356,7 @@ def debug(ctx: click.Context, paths: Sequence[Path]) -> None:
 @click.argument("paths", nargs=-1, type=click.Path(exists=True, path_type=Path))
 def validate_config(ctx: click.Context, paths: Sequence[Path]) -> None:
     """
-    print materialized configuration for paths
+    test the config(s) for the provided path(s)
     """
     options: Options = ctx.obj
 
@@ -368,11 +368,17 @@ def validate_config(ctx: click.Context, paths: Sequence[Path]) -> None:
     except ImportError:
         from pprint import pprint  # type: ignore
 
+    invalid_detected: bool = False
+
     for path in paths:
         try:
             collect_rules(generate_config(path.resolve(), options=options))
         except Exception as e:
             pprint(f"Invalid config: {e.__class__.__name__}: {e}")
-            exit(-1)
+            invalid_detected = True
+
+    if invalid_detected:
+        pprint("Invalid Config(s) Detected")
+        exit(-1)
 
     pprint("Valid Config")

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -356,7 +356,7 @@ def debug(ctx: click.Context, paths: Sequence[Path]) -> None:
 @click.argument("paths", nargs=-1, type=click.Path(exists=True, path_type=Path))
 def validate_config(ctx: click.Context, paths: Sequence[Path]) -> None:
     """
-    test the config(s) for the provided path(s)
+    validate the config(s) for the provided path(s)
     """
     options: Options = ctx.obj
 


### PR DESCRIPTION
## Summary
Added command to Fixit to check if a config file is valid

## Test Plan
Created invalid fixit.toml files such as:
```
[tool.fixit]
enable = [
    "fixit/rules:DeprecatedABCImport",
]
disable = [
  "fixit.rules",
]

root = true
```
and ran the new command against them:
```
# Example from above
$ hatch run fixit validate-config .
Invalid config: ConfigError: invalid rule name 'fixit/rules:DeprecatedABCImport'

# Another example with invalid TOML
$ hatch run fixit validate-config .
Invalid config: TOMLDecodeError: Expected '=' after a key in a key/value pair (at line 9, column 4)
...
```