### PR TITLE
Fix validate config

### DIFF
--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -604,10 +604,10 @@ def validate_config(path: Path) -> List[str]:
     try:
         configs = read_configs([path])[0]
 
-        def validate_rules(rules: List[str], path: Path, context: str) -> None:
+        def validate_rules(rules: List[str], parse_path: Path, context: str) -> None:
             for rule in rules:
                 try:
-                    qualified_rule = parse_rule(rule, path, configs)
+                    qualified_rule = parse_rule(rule, parse_path, configs)
                     try:
                         for _ in find_rules(qualified_rule):
                             pass
@@ -620,20 +620,22 @@ def validate_config(path: Path) -> List[str]:
                         f"Failed to parse rule `{rule}` for {context}: {e.__class__.__name__}: {e}"
                     )
 
+        parse_path = Path(".")
+
         data = configs.data
-        validate_rules(data.get("enable", []), path, "global enable")
-        validate_rules(data.get("disable", []), path, "global disable")
+        validate_rules(data.get("enable", []), parse_path, "global enable")
+        validate_rules(data.get("disable", []), parse_path, "global disable")
 
         for override in data.get("overrides", []):
             override_path = Path(override.get("path", path))
             validate_rules(
                 override.get("enable", []),
-                override_path,
+                parse_path,
                 f"override enable: `{override_path}`",
             )
             validate_rules(
                 override.get("disable", []),
-                override_path,
+                parse_path,
                 f"override disable: `{override_path}`",
             )
 

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -594,7 +594,7 @@ def generate_config(
     return config
 
 
-def validate_config(path: Path, parse_path: Union[Path, None] = None) -> List[str]:
+def validate_config(path: Path, parse_path: Optional[Path] = None) -> List[str]:
     """
     Validate the config provided. The provided path is expected to be a valid toml
     config file. Any exception found while parsing or importing will be added to a list

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -594,11 +594,13 @@ def generate_config(
     return config
 
 
-def validate_config(path: Path) -> List[str]:
+def validate_config(path: Path, parse_path: Union[Path, None] = None) -> List[str]:
     """
     Validate the config provided. The provided path is expected to be a valid toml
     config file. Any exception found while parsing or importing will be added to a list
     of exceptions that are returned.
+
+    The parse_path parameter is used only in testing for when configs are added to temporary directories
     """
     exceptions: List[str] = []
     try:
@@ -620,7 +622,8 @@ def validate_config(path: Path) -> List[str]:
                         f"Failed to parse rule `{rule}` for {context}: {e.__class__.__name__}: {e}"
                     )
 
-        parse_path = Path(".")
+        if not parse_path:
+            parse_path = path.parent
 
         data = configs.data
         validate_rules(data.get("enable", []), parse_path, "global enable")

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -676,7 +676,7 @@ class ConfigTest(TestCase):
                     """
                 )
 
-                results = config.validate_config(path)
+                results = config.validate_config(path, parse_path=Path("."))
 
                 self.assertEqual(results, [])
 
@@ -694,10 +694,14 @@ class ConfigTest(TestCase):
                     [[tool.fixit.overrides]]
                     path = "SUPER_REAL_PATH"
                     enable = [".examples.noop"]
+
+                    [[tool.fixit.overrides]]
+                    path = "SUPER_REAL_PATH/BUT_ACTUALLY_REAL"
+                    enable = [".examples.basic.custom_object"]
                     """
                 )
 
-                results = config.validate_config(path)
+                results = config.validate_config(path, parse_path=Path("."))
 
                 self.assertEqual(results, [])
 
@@ -714,7 +718,7 @@ class ConfigTest(TestCase):
                     """
                 )
 
-                results = config.validate_config(path)
+                results = config.validate_config(path, parse_path=Path("."))
 
                 self.assertEqual(
                     results,
@@ -743,7 +747,7 @@ class ConfigTest(TestCase):
                 path = tdp / "file.py"
                 path.write_text("error")
 
-                results = config.validate_config(config_path)
+                results = config.validate_config(config_path, parse_path=Path("."))
 
                 self.assertEqual(
                     results,

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -680,6 +680,27 @@ class ConfigTest(TestCase):
 
                 self.assertEqual(results, [])
 
+    def test_validate_config_with_override(self) -> None:
+        with self.subTest("validate-config valid with overrides"):
+            with TemporaryDirectory() as td:
+                tdp = Path(td).resolve()
+                path = tdp / ".fixit.toml"
+                path.write_text(
+                    """
+                    [tool.fixit]
+                    disable = ["fixit.rules"]
+                    root = true
+
+                    [[tool.fixit.overrides]]
+                    path = "SUPER_REAL_PATH"
+                    enable = [".examples.noop"]
+                    """
+                )
+
+                results = config.validate_config(path)
+
+                self.assertEqual(results, [])
+
         with self.subTest("validate-config invalid config"):
             with TemporaryDirectory() as td:
                 tdp = Path(td).resolve()

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -676,7 +676,7 @@ class ConfigTest(TestCase):
                     """
                 )
 
-                results = config.validate_config(path, parse_path=Path("."))
+                results = config.validate_config(path)
 
                 self.assertEqual(results, [])
 
@@ -685,6 +685,10 @@ class ConfigTest(TestCase):
             with TemporaryDirectory() as td:
                 tdp = Path(td).resolve()
                 path = tdp / ".fixit.toml"
+                (tdp / "rule/ruledir").mkdir(parents=True, exist_ok=True)
+
+                (tdp / "rule/rule.py").write_text("# Rule")
+                (tdp / "rule/ruledir/rule.py").write_text("# Rule")
                 path.write_text(
                     """
                     [tool.fixit]
@@ -693,15 +697,15 @@ class ConfigTest(TestCase):
 
                     [[tool.fixit.overrides]]
                     path = "SUPER_REAL_PATH"
-                    enable = [".examples.noop"]
+                    enable = [".rule.rule"]
 
                     [[tool.fixit.overrides]]
                     path = "SUPER_REAL_PATH/BUT_ACTUALLY_REAL"
-                    enable = [".examples.basic.custom_object"]
+                    enable = [".rule.ruledir.rule"]
                     """
                 )
 
-                results = config.validate_config(path, parse_path=Path("."))
+                results = config.validate_config(path)
 
                 self.assertEqual(results, [])
 
@@ -718,7 +722,7 @@ class ConfigTest(TestCase):
                     """
                 )
 
-                results = config.validate_config(path, parse_path=Path("."))
+                results = config.validate_config(path)
 
                 self.assertEqual(
                     results,
@@ -747,7 +751,7 @@ class ConfigTest(TestCase):
                 path = tdp / "file.py"
                 path.write_text("error")
 
-                results = config.validate_config(config_path, parse_path=Path("."))
+                results = config.validate_config(config_path)
 
                 self.assertEqual(
                     results,


### PR DESCRIPTION
## Summary
The initial implementation would fail for overrides, since the path provided into `parse_rule` is the override path, instead of the path to the config file, which is expected.

## Test Plan
Included