### PR TITLE
Add fixit rule for variadic callable syntax

### DIFF
--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -43,6 +43,7 @@ Built-in Rules
 - :class:`UseClsInClassmethod`
 - :class:`UseFstring`
 - :class:`UseTypesFromTyping`
+- :class:`VariadicCallableSyntax`
 
 .. class:: AvoidOrInExcept
 
@@ -1493,3 +1494,20 @@ Built-in Rules
             from fixit import LintRule
             class CatsRuleDogsDroolRule(LintRule): ...
     
+.. class:: VariadicCallableSyntax
+
+    Callable types with arbitrary parameters are written as `Callable[..., T]`, not `Callable[[...], T]`
+
+    .. attribute:: AUTOFIX
+        :type: Yes
+
+    .. attribute:: VALID
+
+        .. code:: python
+            from typing import Callable
+            x: Callable[..., int]
+    .. attribute:: INVALID
+
+        .. code:: python
+            from typing import Callable
+            x: Callable[[...], int]

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -1264,6 +1264,7 @@ Built-in Rules
         .. code:: python
             from typing import Callable
             x: Callable[..., int]
+
     .. attribute:: INVALID
 
         .. code:: python

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -1251,7 +1251,6 @@ Built-in Rules
 
             def function(list: list[str]) -> None:
                 pass
-
 .. class:: VariadicCallableSyntax
 
     Callable types with arbitrary parameters are written as `Callable[..., T]`, not `Callable[[...], T]`
@@ -1259,17 +1258,38 @@ Built-in Rules
     .. attribute:: AUTOFIX
         :type: Yes
 
+
     .. attribute:: VALID
 
         .. code:: python
+
             from typing import Callable
-            x: Callable[..., int]
+            x: Callable[[int], int]
+        .. code:: python
+
+            from typing import Callable
+            x: Callable[[int, int, ...], int]
 
     .. attribute:: INVALID
 
         .. code:: python
+
             from typing import Callable
-            x: Callable[[...], int]
+            x: Callable[[...], int] = ...
+
+            # suggested fix
+            from typing import Callable
+            x: Callable[..., int] = ...
+
+        .. code:: python
+
+            import typing as t
+            x: t.Callable[[...], int] = ...
+
+            # suggested fix
+            import typing as t
+            x: t.Callable[..., int] = ...
+
 
 ``fixit.rules.extra``
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -1253,13 +1253,15 @@ Built-in Rules
                 pass
 .. class:: VariadicCallableSyntax
 
-    Callable types with arbitrary parameters are written as `Callable[..., T]`, not `Callable[[...], T]`
+    Callable types with arbitrary parameters should be written as `Callable[..., T]`
 
     .. attribute:: AUTOFIX
+        :no-index:
         :type: Yes
 
 
     .. attribute:: VALID
+        :no-index:
 
         .. code:: python
 
@@ -1271,6 +1273,7 @@ Built-in Rules
             x: Callable[[int, int, ...], int]
 
     .. attribute:: INVALID
+        :no-index:
 
         .. code:: python
 

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -1252,6 +1252,24 @@ Built-in Rules
             def function(list: list[str]) -> None:
                 pass
 
+.. class:: VariadicCallableSyntax
+
+    Callable types with arbitrary parameters are written as `Callable[..., T]`, not `Callable[[...], T]`
+
+    .. attribute:: AUTOFIX
+        :type: Yes
+
+    .. attribute:: VALID
+
+        .. code:: python
+            from typing import Callable
+            x: Callable[..., int]
+    .. attribute:: INVALID
+
+        .. code:: python
+            from typing import Callable
+            x: Callable[[...], int]
+
 ``fixit.rules.extra``
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -1493,21 +1511,3 @@ Built-in Rules
 
             from fixit import LintRule
             class CatsRuleDogsDroolRule(LintRule): ...
-    
-.. class:: VariadicCallableSyntax
-
-    Callable types with arbitrary parameters are written as `Callable[..., T]`, not `Callable[[...], T]`
-
-    .. attribute:: AUTOFIX
-        :type: Yes
-
-    .. attribute:: VALID
-
-        .. code:: python
-            from typing import Callable
-            x: Callable[..., int]
-    .. attribute:: INVALID
-
-        .. code:: python
-            from typing import Callable
-            x: Callable[[...], int]

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -1532,4 +1532,4 @@ Built-in Rules
 
             from fixit import LintRule
             class CatsRuleDogsDroolRule(LintRule): ...
-
+    

--- a/docs/guide/builtins.rst
+++ b/docs/guide/builtins.rst
@@ -1532,3 +1532,4 @@ Built-in Rules
 
             from fixit import LintRule
             class CatsRuleDogsDroolRule(LintRule): ...
+

--- a/src/fixit/rules/variadic_callable_syntax.py
+++ b/src/fixit/rules/variadic_callable_syntax.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.metadata import QualifiedName, QualifiedNameProvider, QualifiedNameSource
+
+from fixit import Invalid, LintRule, Valid
+
+
+class VariadicCallableSyntax(LintRule):
+    """
+    Callable types with arbitrary parameters are written as `Callable[..., T]`, not `Callable[[...], T]`
+    """
+
+    METADATA_DEPENDENCIES = (QualifiedNameProvider,)
+    VALID = [
+        Valid(
+            """
+            from typing import Callable
+            x: Callable[[int], int]
+            """
+        ),
+        Valid(
+            """
+            from typing import Callable
+            x: Callable[[int, int, ...], int]
+            """
+        ),
+        Valid(
+            """
+            from typing import Callable
+            x: Callable
+            """
+        ),
+        Valid(
+            """
+            from typing import Callable as C
+            x: C[..., int] = ...
+            """
+        ),
+        Valid(
+            """
+            from typing import Callable
+            def foo(bar: Optional[Callable[..., int]]) -> Callable[..., int]:
+                ...
+            """
+        ),
+        Valid(
+            """
+            import typing as t
+            x: t.Callable[..., int] = ...
+            """
+        ),
+        Valid(
+            """
+            from typing import Callable
+            x: Callable[..., int] = ...
+            """
+        ),
+    ]
+    INVALID = [
+        Invalid(
+            """
+            from typing import Callable
+            x: Callable[[...], int] = ...
+            """,
+            expected_replacement="""
+            from typing import Callable
+            x: Callable[..., int] = ...
+            """,
+        ),
+        Invalid(
+            """
+            import typing as t
+            x: t.Callable[[...], int] = ...
+            """,
+            expected_replacement="""
+            import typing as t
+            x: t.Callable[..., int] = ...
+            """,
+        ),
+        Invalid(
+            """
+            from typing import Callable as C
+            x: C[[...], int] = ...
+            """,
+            expected_replacement="""
+            from typing import Callable as C
+            x: C[..., int] = ...
+            """,
+        ),
+        Invalid(
+            """
+            from typing import Callable
+            def foo(bar: Optional[Callable[[...], int]]) -> Callable[[...], int]:
+                ...
+            """,
+            expected_replacement="""
+            from typing import Callable
+            def foo(bar: Optional[Callable[..., int]]) -> Callable[..., int]:
+                ...
+            """,
+        ),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def visit_Subscript(self, node: cst.Subscript) -> None:
+        if not QualifiedNameProvider.has_name(
+            self,
+            node,
+            QualifiedName(name="typing.Callable", source=QualifiedNameSource.IMPORT),
+        ):
+            return
+        node_matches = len(node.slice) == 2 and m.matches(
+            node.slice[0],
+            m.SubscriptElement(
+                slice=m.Index(value=m.List(elements=[m.Element(m.Ellipsis())]))
+            ),
+        )
+        if not node_matches:
+            return
+        slices = list(node.slice)
+        slices[0] = cst.SubscriptElement(cst.Index(cst.Ellipsis()))
+        new_node = node.with_changes(slice=slices)
+        self.report(
+            node,
+            "Callable types with arbitrary parameters are written as `Callable[..., T]`, not `Callable[[...], T]`",
+            replacement=node.deep_replace(node, new_node),
+        )


### PR DESCRIPTION
## Summary

`Callable[[...], T]` -> `Callable[..., T]`

Adding a fixit rule in addition to a codemod, per suggestion in https://github.com/Instagram/LibCST/pull/1269

## Test Plan

hatch run test