### PR TITLE
Allow dash in rule names

### DIFF
--- a/src/fixit/ftypes.py
+++ b/src/fixit/ftypes.py
@@ -94,9 +94,9 @@ QualifiedRuleRegex = re.compile(
     ^
     (?P<module>
         (?P<local>\.)?
-        [a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)*
+        [a-zA-Z0-9_]+(\.[a-zA-Z0-9_-]+)*
     )
-    (?::(?P<name>[a-zA-Z0-9_]+))?
+    (?::(?P<name>[a-zA-Z0-9_-]+))?
     $
     """,
     re.VERBOSE,


### PR DESCRIPTION
Since rules are dynamically imported, they don't actually have to adhere to identifier naming.

This allows putting rules in directories with `-` in them.
