### PR TITLE
Update pyrefly configuration.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "mypy == 1.13.0",
     "ufmt == 2.8.0",
     "usort == 1.0.8.post1",
-    "pyrefly == 0.8.0",
+    "pyrefly == 0.11.0",
 ]
 lsp = [
     "pygls[ws] ~= 1.3.1",
@@ -143,8 +143,5 @@ project_includes = [
 ]
 search_path = [
     "src"
-]
-site_package_path = [
-    "venv/lib/python3.12/site-packages"
 ]
 python_version = "3.12"


### PR DESCRIPTION
## Summary
* Bump pyrefly version from 0.8.0 to 0.11.0
* Remove hard-coded site_package_path. This doesn't seem to be the right path; note the warning about a non-existing site_package_path when I try to expand pyrefly_check to the full project: https://github.com/rchen152/Fixit/actions/runs/14458470131/job/40546523189. With this path removed, pyrefly auto-discovers the right path on macos and linux: https://github.com/rchen152/Fixit/actions/runs/14458313231. Windows doesn't seem to work yet.

## Test Plan
See links in Summary - I forked Fixit and changed `project_includes` to run pyrefly over the entire project to see the errors produced.