### PR TITLE
Expand files checked by Pyrefly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,13 +138,11 @@ warn_unused_ignores = false
 
 [tool.pyrefly]
 project_includes = [
-    # Start by adding a single file and we'll expand as we go
     "src/fixit"
 ]
 search_path = [
     "src"
 ]
-python_version = "3.12"
 [tool.pyrefly.errors]
 bad-argument-type = false
 missing-attribute = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "mypy == 1.13.0",
     "ufmt == 2.8.0",
     "usort == 1.0.8.post1",
-    "pyrefly == 0.11.0",
+    "pyrefly == 0.11.1",
 ]
 lsp = [
     "pygls[ws] ~= 1.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,9 +139,14 @@ warn_unused_ignores = false
 [tool.pyrefly]
 project_includes = [
     # Start by adding a single file and we'll expand as we go
-    "src/fixit/util.py"
+    "src/fixit"
 ]
 search_path = [
     "src"
 ]
 python_version = "3.12"
+[tool.pyrefly.errors]
+bad-argument-type = false
+missing-attribute = false
+unexpected-keyword = false
+internal-error = false

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -172,6 +172,7 @@ def fixit_stdin(
         content: FileContent = sys.stdin.buffer.read()
         config = generate_config(path, options=options)
 
+        # pyrefly: ignore  # invalid-yield
         updated = yield from fixit_bytes(
             path, content, config=config, autofix=autofix, metrics_hook=metrics_hook
         )
@@ -207,6 +208,7 @@ def fixit_file(
         content: FileContent = path.read_bytes()
         config = generate_config(path, options=options)
 
+        # pyrefly: ignore  # invalid-yield
         updated = yield from fixit_bytes(
             path, content, config=config, autofix=autofix, metrics_hook=metrics_hook
         )

--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -75,6 +75,7 @@ def splash(
 @click.option(
     "--output-format",
     "-o",
+    # pyrefly: ignore  # bad-argument-count, no-matching-overload
     type=click.Choice([o.name for o in OutputFormat], case_sensitive=False),
     show_choices=True,
     default=None,

--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -230,6 +230,7 @@ def collect_rules(
                 rules = set(find_rules(qualified_rule))
                 if qualified_rule.name:
                     named_enables |= rules
+                # pyrefly: ignore  # not-callable
                 all_rules |= rules
             except Exception as e:
                 log.warning(
@@ -245,6 +246,7 @@ def collect_rules(
                         if r not in named_enables
                     }
                 )
+                # pyrefly: ignore  # not-callable
                 all_rules -= set(disabled_rules)
             except Exception as e:
                 log.warning(
@@ -255,6 +257,7 @@ def collect_rules(
             disabled_rules.update(
                 {R: "tags" for R in all_rules if R.TAGS not in config.tags}  # type: ignore[comparison-overlap]
             )
+            # pyrefly: ignore  # not-callable
             all_rules -= set(disabled_rules)
 
         if config.python_version is not None:
@@ -374,6 +377,7 @@ def get_options(
                     config=config,
                 )
 
+            # pyrefly: ignore  # bad-specialization
             rule_configs[rule_name][key] = value
 
     return rule_configs
@@ -436,13 +440,16 @@ def merge_configs(
         except ValueError:  # not relative to subpath
             return
 
+        # pyrefly: ignore  # unbound-name
         config_dir = config.path.parent
         for rule in enable:
+            # pyrefly: ignore  # unbound-name
             qual_rule = parse_rule(rule, config_dir, config)
             enable_rules.add(qual_rule)
             disable_rules.discard(qual_rule)
 
         for rule in disable:
+            # pyrefly: ignore  # unbound-name
             qual_rule = parse_rule(rule, config_dir, config)
             enable_rules.discard(qual_rule)
             disable_rules.add(qual_rule)
@@ -457,6 +464,7 @@ def merge_configs(
                 except InvalidVersion:
                     raise ConfigError(
                         f"'python-version' {python_version!r} is not valid",
+                        # pyrefly: ignore  # unbound-name
                         config=config,
                     )
 
@@ -466,6 +474,7 @@ def merge_configs(
         if formatter:
             if formatter not in FORMAT_STYLES:
                 raise ConfigError(
+                    # pyrefly: ignore  # unbound-name
                     f"'formatter' {formatter!r} not supported", config=config
                 )
 
@@ -500,6 +509,7 @@ def merge_configs(
 
         if value := data.pop("output-format", ""):
             try:
+                # pyrefly: ignore  # bad-assignment
                 output_format = OutputFormat(value)
             except ValueError as e:
                 raise ConfigError(

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -118,6 +118,7 @@ class LintRunner:
         self.metrics["Count.Total"] = count
 
         if metrics_hook:
+            # pyrefly: ignore  # not-callable
             metrics_hook(self.metrics)
 
         return count

--- a/src/fixit/rule.py
+++ b/src/fixit/rule.py
@@ -103,6 +103,7 @@ class LintRule(BatchableCSTVisitor):
 
     def __init_subclass__(cls) -> None:
         if ParentNodeProvider not in cls.METADATA_DEPENDENCIES:
+            # pyrefly: ignore  # read-only
             cls.METADATA_DEPENDENCIES = (*cls.METADATA_DEPENDENCIES, ParentNodeProvider)
 
         invalid: List[Union[str, Invalid]] = getattr(cls, "INVALID", [])
@@ -273,6 +274,7 @@ class LintRule(BatchableCSTVisitor):
                         return func(node)
                 return func(node)
 
+            # pyrefly: ignore  # bad-return
             return wrapper
 
         return {

--- a/src/fixit/rules/chained_instance_check.py
+++ b/src/fixit/rules/chained_instance_check.py
@@ -157,6 +157,7 @@ class CollapseIsinstanceChecks(LintRule):
                 target, match = call.args[0].value, call.args[1].value
                 for possible_target in targets:
                     if target.deep_equals(possible_target):
+                        # pyrefly: ignore  # bad-specialization
                         targets[possible_target].append(match)
                         break
                 else:

--- a/src/fixit/rules/deprecated_abc_import.py
+++ b/src/fixit/rules/deprecated_abc_import.py
@@ -188,6 +188,7 @@ class DeprecatedABCImport(LintRule):
 
         # Get imports in this statement
         import_names = (
+            # pyrefly: ignore  # not-iterable
             [name.name.value for name in node.names]
             if type(node.names) is tuple
             else []
@@ -208,6 +209,7 @@ class DeprecatedABCImport(LintRule):
                 # so that we can add an additional `SimpleStatementLine` for the new
                 # import
                 self.update_module = True
+                # pyrefly: ignore  # bad-assignment
                 self.imports_names = import_names
             else:
                 self.report(
@@ -236,8 +238,10 @@ class DeprecatedABCImport(LintRule):
                 ),
             ),
         )
+        # pyrefly: ignore  # bad-return
         return imp[0] if len(imp) > 0 and isinstance(imp[0], cst.ImportFrom) else None
 
+    # pyrefly: ignore  # bad-override
     def leave_Module(self, node: cst.Module) -> None:
         """
         While leaving the module, check if we need to split up imports.

--- a/src/fixit/rules/no_redundant_arguments_super.py
+++ b/src/fixit/rules/no_redundant_arguments_super.py
@@ -145,6 +145,8 @@ class NoRedundantArgumentsSuper(LintRule):
         # `super(Foo.InnerFoo, self)` for example.
         if len(self.current_classes) > 1:
             for class_name in self.current_classes[1:]:
+                # pyrefly: ignore  # unknown
                 matcher = m.Attribute(value=matcher, attr=m.Name(value=class_name))
 
+        # pyrefly: ignore  # bad-return
         return matcher

--- a/src/fixit/rules/use_async_sleep_in_async_def.py
+++ b/src/fixit/rules/use_async_sleep_in_async_def.py
@@ -120,6 +120,7 @@ class UseAsyncSleepInAsyncDef(LintRule):
     def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
         self.async_func = node.asynchronous is not None
 
+    # pyrefly: ignore  # bad-override
     def leave_FunctionDef(self, node: cst.FunctionDef) -> None:
         self.async_func = False
 

--- a/src/fixit/testing.py
+++ b/src/fixit/testing.py
@@ -184,6 +184,7 @@ def generate_lint_rule_test_cases(
             test_method.__name__ = test_method_name
             test_methods_to_add[test_method_name] = test_method
 
+        # pyrefly: ignore  # no-matching-overload
         test_case_class = type(rule_name, (LintRuleTestCase,), test_methods_to_add)
         test_case_classes.append(test_case_class)
 
@@ -227,4 +228,5 @@ def add_lint_rule_tests_to_module(
         test_module = module_attrs.get("__package__")
         assert isinstance(test_module, str)
         for test_case_class in test_case_classes:
+            # pyrefly: ignore  # no-access
             test_case_class.__module__ = test_module

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -28,6 +28,7 @@ from ..util import chdir
 
 
 class ConfigTest(TestCase):
+    # pyrefly: ignore  # bad-override
     maxDiff = None
 
     def setUp(self) -> None:
@@ -456,6 +457,7 @@ class ConfigTest(TestCase):
         ):
             with self.subTest(name):
                 actual = config.generate_config(path, root, options=options)
+                # pyrefly: ignore  # no-matching-overload, no-matching-overload
                 self.assertDictEqual(asdict(expected), asdict(actual))
 
     def test_invalid_config(self) -> None:

--- a/src/fixit/upgrade/deprecated_import.py
+++ b/src/fixit/upgrade/deprecated_import.py
@@ -91,6 +91,7 @@ class FixitDeprecatedImport(LintRule):
         if isinstance(node.module, libcst.Name) and isinstance(node.names, Sequence):
             module = node.module.value
 
+            # pyrefly: ignore  # not-iterable
             for alias in node.names:
                 fqname = f"{module}.{alias.name.value}"
 

--- a/src/fixit/upgrade/deprecated_testcase_keywords.py
+++ b/src/fixit/upgrade/deprecated_testcase_keywords.py
@@ -63,6 +63,7 @@ class FixitDeprecatedTestCaseKeywords(LintRule):
         ),
     ]
 
+    # pyrefly: ignore  # bad-override
     def visit_Module(self, module: Module) -> None:
         self.module = module
 


### PR DESCRIPTION
## Summary

This adds configuration options to minimize the amount of errors added, and then runs our silencer script over the entire project (adding ~30 type suppressions). 

This makes  the surface area checked by Pyrefly equivalent to the files type checked by MyPy

## Test Plan
hatch run pyrefly_check 
CI