### PR TITLE
Fix version specifier matching for prerelease versions

### DIFF
--- a/src/fixit/config.py
+++ b/src/fixit/config.py
@@ -262,7 +262,9 @@ def collect_rules(
                 {
                     R: "python-version"
                     for R in all_rules
-                    if config.python_version not in SpecifierSet(R.PYTHON_VERSION)
+                    if R.PYTHON_VERSION
+                    and config.python_version
+                    not in SpecifierSet(R.PYTHON_VERSION, prereleases=True)
                 }
             )
             all_rules -= set(disabled_rules)

--- a/src/fixit/tests/config.py
+++ b/src/fixit/tests/config.py
@@ -539,7 +539,15 @@ class ConfigTest(TestCase):
         with self.subTest("version match"):
             rules = collect_types(
                 Config(
-                    python_version=Version("3.7"),
+                    python_version=Version("3.7.10"),
+                )
+            )
+            self.assertIn(UseTypesFromTyping, rules)
+
+        with self.subTest("version match alpha"):
+            rules = collect_types(
+                Config(
+                    python_version=Version("3.7.10a3"),
                 )
             )
             self.assertIn(UseTypesFromTyping, rules)
@@ -547,7 +555,15 @@ class ConfigTest(TestCase):
         with self.subTest("version mismatch"):
             rules = collect_types(
                 Config(
-                    python_version=Version("3.10"),
+                    python_version=Version("3.10.5"),
+                )
+            )
+            self.assertNotIn(UseTypesFromTyping, rules)
+
+        with self.subTest("version mismatch alpha"):
+            rules = collect_types(
+                Config(
+                    python_version=Version("3.10.5a4"),
                 )
             )
             self.assertNotIn(UseTypesFromTyping, rules)


### PR DESCRIPTION
SpecifierSet would fail to match a rule when running Fixit from a
prerelease version of Python (eg, 3.14.0a7). This allows the specifier
set to include prerelease versions when matching which rules should be
enabled at runtime.
