### PR TITLE
Exit with non-zero when autofix not applied

### DIFF
--- a/src/fixit/cli.py
+++ b/src/fixit/cli.py
@@ -218,27 +218,44 @@ def fix(
         visited.add(result.path)
         # for STDIN, we need STDOUT to equal the fixed content, so
         # move everything else to STDERR
-        if print_result(
+        is_dirty = print_result(
             result,
             show_diff=interactive or diff,
             stderr=is_stdin,
             output_format=config.output_format,
             output_template=config.output_template,
-        ):
+        )
+        if is_dirty:
             dirty.add(result.path)
-            if autofix and result.violation and result.violation.autofixable:
-                autofixes += 1
-                fixed += 1
-        if interactive and result.violation and result.violation.autofixable:
+
+        if result.error:
+            exit_code |= 2
+            continue
+
+        violation = result.violation
+        if not violation:
+            continue
+
+        violation_fixed = False
+        if violation.autofixable:
             autofixes += 1
-            answer = click.prompt(
-                "Apply autofix?", default="y", type=click.Choice("ynq", False)
-            )
-            if answer == "y":
-                generator.respond(True)  # noqa: B038
+            if autofix:
                 fixed += 1
-            elif answer == "q":
-                break
+                violation_fixed = True
+            elif interactive:
+                answer = click.prompt(
+                    "Apply autofix?", default="y", type=click.Choice("ynq", False)
+                )
+                if answer == "y":
+                    generator.respond(True)  # noqa: B038
+                    fixed += 1
+                    violation_fixed = True
+                elif answer == "q":
+                    exit_code |= 1
+                    break
+
+        if not violation_fixed:
+            exit_code |= 1
 
     splash(visited, dirty, autofixes, fixed)
     ctx.exit(exit_code)

--- a/src/fixit/tests/smoke.py
+++ b/src/fixit/tests/smoke.py
@@ -209,6 +209,53 @@ class SmokeTest(TestCase):
             self.assertIn("broken.py: EXCEPTION: Syntax Error @ 1:", result.output)
             self.assertEqual(result.exit_code, 3)
 
+    def test_fix_exit_codes(self) -> None:
+        with self.subTest("unfixable violation"):
+            with TemporaryDirectory() as td:
+                tdp = Path(td).resolve()
+                dirty = tdp / "dirty.py"
+                dirty.write_text(
+                    "try:\n    pass\nexcept ValueError or KeyError:\n    pass\n"
+                )
+
+                result = self.runner.invoke(
+                    main, ["fix", "--automatic", dirty.as_posix()], catch_exceptions=False
+                )
+
+                self.assertIn("AvoidOrInExcept", result.output)
+                self.assertEqual(result.exit_code, 1)
+
+        with self.subTest("syntax error"):
+            with TemporaryDirectory() as td:
+                tdp = Path(td).resolve()
+                broken = tdp / "broken.py"
+                broken.write_text("print)\n")
+
+                result = self.runner.invoke(
+                    main,
+                    ["fix", "--automatic", broken.as_posix()],
+                    catch_exceptions=False,
+                )
+
+                self.assertIn("EXCEPTION: Syntax Error", result.output)
+                self.assertEqual(result.exit_code, 2)
+
+        with self.subTest("violations and errors together"):
+            with TemporaryDirectory() as td:
+                tdp = Path(td).resolve()
+                (tdp / "dirty.py").write_text(
+                    "try:\n    pass\nexcept ValueError or KeyError:\n    pass\n"
+                )
+                (tdp / "broken.py").write_text("print)\n")
+
+                result = self.runner.invoke(
+                    main, ["fix", "--automatic", td], catch_exceptions=False
+                )
+
+                self.assertIn("AvoidOrInExcept", result.output)
+                self.assertIn("EXCEPTION: Syntax Error", result.output)
+                self.assertEqual(result.exit_code, 3)
+
     def test_directory_with_autofixes(self) -> None:
         with TemporaryDirectory() as td:
             tdp = Path(td).resolve()


### PR DESCRIPTION
## Summary

Closes #409 

This PR improves the exit code handling in the `fix` command when multiple issues are encountered in a single run.

* Refactored the `fix` command in `src/fixit/cli.py` to set exit codes more accurately: now, exit code `2` is set for syntax errors, exit code `1` for unfixable violations, and both are combined to 3 if both types of issues are present. This ensures that the CLI communicates the exact result of the operation.
* This is in accordance to https://github.com/Instagram/Fixit/commit/5e49b17a135b807ac03ab130cb4c782f9609e13d
    > Return non-zero exit codes for violations/errors
	> 
	> This tracks exit codes based on the existence of violations and/or
	> errors when linting files.
	> 
	> - 0: everything clean
	> - 1: violations only
	> - 2: errors only
	> - 3: both violations and errors
	> 
	> Fixes https://github.com/Instagram/Fixit/issues/258
	> 
	> ghstack-source-id: https://github.com/Instagram/Fixit/commit/2c18d7a06f67313d29863e55a6cb45a97c655146
	> Pull Request resolved: https://github.com/Instagram/Fixit/pull/283

## Test Plan

* Added a new test method `test_fix_exit_codes` to verify the exit codes for unfixable violations, syntax errors, and scenarios where both occur together.