### PR TITLE
Bump python minimum version to 3.10 - 3.9 is past end-of-life

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "click >= 8.0, < 8.2",
     "libcst >= 0.3.18",


### PR DESCRIPTION
## Summary

This is necessary for `uv sync` to even work, otherwise it detects that the version of isort we *already* require does not support 3.9

## Test Plan

```
uv venv .venv
. .venv/bin/activate
uv sync
```
now works - it was crashing on trunk due to the dependency mismatch
